### PR TITLE
Unexpected server crashes now mark the test as failed

### DIFF
--- a/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
@@ -27,7 +27,7 @@ import org.terracotta.testing.logging.VerboseLogger;
 
 public class BasicHarnessEntry extends AbstractHarnessEntry<BasicTestClusterConfiguration> {
   // Run the one configuration.
-  protected boolean runOneConfiguration(ITestStateManager stateManager, VerboseLogger logger, ContextualLogger fileHelperLogger, String kitOriginPath, String configTestDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, BasicTestClusterConfiguration runConfiguration) throws IOException, FileNotFoundException, InterruptedException {
+  protected void runOneConfiguration(ITestStateManager stateManager, VerboseLogger logger, ContextualLogger fileHelperLogger, String kitOriginPath, String configTestDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, BasicTestClusterConfiguration runConfiguration) throws IOException, FileNotFoundException, InterruptedException {
     int serversToCreate = runConfiguration.serversInStripe;
     Assert.assertTrue(serversToCreate > 0);
     
@@ -40,10 +40,10 @@ public class BasicHarnessEntry extends AbstractHarnessEntry<BasicTestClusterConf
     Assert.assertTrue(null != processControl);
     Assert.assertTrue(null != connectUri);
     
+    // Set up our termination controller in the state manager.
+    stateManager.setShutdownControl(processControl);
+    
     // The cluster is now running so install and run the clients.
-    boolean wasCompleteSuccess = CommonIdioms.installAndRunClients(stateManager, logger, configTestDirectory, clientClassPath, debugOptions, clientsToCreate, testClassName, processControl, connectUri);
-    // Stop all the servers.
-    processControl.shutDown();
-    return wasCompleteSuccess;
+    CommonIdioms.installAndRunClients(stateManager, logger, configTestDirectory, clientClassPath, debugOptions, clientsToCreate, testClassName, processControl, connectUri);
   }
 }

--- a/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
@@ -27,13 +27,13 @@ import org.terracotta.testing.logging.VerboseLogger;
 
 public class BasicHarnessEntry extends AbstractHarnessEntry<BasicTestClusterConfiguration> {
   // Run the one configuration.
-  protected boolean runOneConfiguration(VerboseLogger logger, ContextualLogger fileHelperLogger, String kitOriginPath, String configTestDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, BasicTestClusterConfiguration runConfiguration) throws IOException, FileNotFoundException, InterruptedException {
+  protected boolean runOneConfiguration(ITestStateManager stateManager, VerboseLogger logger, ContextualLogger fileHelperLogger, String kitOriginPath, String configTestDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, BasicTestClusterConfiguration runConfiguration) throws IOException, FileNotFoundException, InterruptedException {
     int serversToCreate = runConfiguration.serversInStripe;
     Assert.assertTrue(serversToCreate > 0);
     
     // This is the simple case of a single-stripe so we don't need to wrap or decode anything.
     String stripeName = "stripe" + 0;
-    ReadyStripe oneStripe = CommonIdioms.setupConfigureAndStartStripe(logger, fileHelperLogger, kitOriginPath, configTestDirectory, serversToCreate, SERVER_START_PORT, 0, isRestartable, extraJarPaths, namespaceFragment, serviceFragment, stripeName);
+    ReadyStripe oneStripe = CommonIdioms.setupConfigureAndStartStripe(stateManager, logger, fileHelperLogger, kitOriginPath, configTestDirectory, serversToCreate, SERVER_START_PORT, 0, isRestartable, extraJarPaths, namespaceFragment, serviceFragment, stripeName);
     // We just want to unwrap this, directly.
     IMultiProcessControl processControl = oneStripe.stripeControl;
     String connectUri = oneStripe.stripeUri;
@@ -41,7 +41,7 @@ public class BasicHarnessEntry extends AbstractHarnessEntry<BasicTestClusterConf
     Assert.assertTrue(null != connectUri);
     
     // The cluster is now running so install and run the clients.
-    boolean wasCompleteSuccess = CommonIdioms.installAndRunClients(logger, configTestDirectory, clientClassPath, debugOptions, clientsToCreate, testClassName, processControl, connectUri);
+    boolean wasCompleteSuccess = CommonIdioms.installAndRunClients(stateManager, logger, configTestDirectory, clientClassPath, debugOptions, clientsToCreate, testClassName, processControl, connectUri);
     // Stop all the servers.
     processControl.shutDown();
     return wasCompleteSuccess;

--- a/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
@@ -40,8 +40,12 @@ public class BasicHarnessEntry extends AbstractHarnessEntry<BasicTestClusterConf
     Assert.assertTrue(null != processControl);
     Assert.assertTrue(null != connectUri);
     
-    // Set up our termination controller in the state manager.
-    stateManager.setShutdownControl(processControl);
+    // Register to shut down the process control (the servers in the stripe) once the test has passed/failed.
+    stateManager.addComponentToShutDown(new IComponentManager() {
+      @Override
+      public void forceTerminateComponent() {
+        processControl.shutDown();
+      }});
     
     // The cluster is now running so install and run the clients.
     CommonIdioms.installAndRunClients(stateManager, logger, configTestDirectory, clientClassPath, debugOptions, clientsToCreate, testClassName, processControl, connectUri);

--- a/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
@@ -68,10 +68,11 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     boolean wasCompleteSuccess = true;
     int clientsToCreate = master.getClientsToStart();
     for (C runConfiguration : runConfigurations) {
+      ITestStateManager stateManager = null;
       String configurationName = runConfiguration.getName();
       // We want to create a sub-directory per-configuration.
       String configTestDirectory = FileHelpers.createTempEmptyDirectory(environmentOptions.testParentDirectory, configurationName);
-      boolean runWasSuccess = runOneConfiguration(logger, fileHelperLogger, environmentOptions.serverInstallDirectory, configTestDirectory, environmentOptions.clientClassPath, debugOptions, clientsToCreate, testClassName, isRestartable, extraJarPaths, namespaceFragment, serviceFragment, runConfiguration);
+      boolean runWasSuccess = runOneConfiguration(stateManager, logger, fileHelperLogger, environmentOptions.serverInstallDirectory, configTestDirectory, environmentOptions.clientClassPath, debugOptions, clientsToCreate, testClassName, isRestartable, extraJarPaths, namespaceFragment, serviceFragment, runConfiguration);
       if (!runWasSuccess) {
         wasCompleteSuccess = false;
         break;
@@ -81,5 +82,5 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
   }
 
   // Run the one configuration.
-  protected abstract boolean runOneConfiguration(VerboseLogger logger, ContextualLogger fileHelperLogger, String kitOriginPath, String configTestDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, C runConfiguration) throws IOException, FileNotFoundException, InterruptedException;
+  protected abstract boolean runOneConfiguration(ITestStateManager stateManager, VerboseLogger logger, ContextualLogger fileHelperLogger, String kitOriginPath, String configTestDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, C runConfiguration) throws IOException, FileNotFoundException, InterruptedException;
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
@@ -68,11 +68,12 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     boolean wasCompleteSuccess = true;
     int clientsToCreate = master.getClientsToStart();
     for (C runConfiguration : runConfigurations) {
-      ITestStateManager stateManager = null;
+      TestStateManager stateManager = new TestStateManager();
       String configurationName = runConfiguration.getName();
       // We want to create a sub-directory per-configuration.
       String configTestDirectory = FileHelpers.createTempEmptyDirectory(environmentOptions.testParentDirectory, configurationName);
-      boolean runWasSuccess = runOneConfiguration(stateManager, logger, fileHelperLogger, environmentOptions.serverInstallDirectory, configTestDirectory, environmentOptions.clientClassPath, debugOptions, clientsToCreate, testClassName, isRestartable, extraJarPaths, namespaceFragment, serviceFragment, runConfiguration);
+      runOneConfiguration(stateManager, logger, fileHelperLogger, environmentOptions.serverInstallDirectory, configTestDirectory, environmentOptions.clientClassPath, debugOptions, clientsToCreate, testClassName, isRestartable, extraJarPaths, namespaceFragment, serviceFragment, runConfiguration);
+      boolean runWasSuccess = stateManager.waitForFinish();
       if (!runWasSuccess) {
         wasCompleteSuccess = false;
         break;
@@ -82,5 +83,5 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
   }
 
   // Run the one configuration.
-  protected abstract boolean runOneConfiguration(ITestStateManager stateManager, VerboseLogger logger, ContextualLogger fileHelperLogger, String kitOriginPath, String configTestDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, C runConfiguration) throws IOException, FileNotFoundException, InterruptedException;
+  protected abstract void runOneConfiguration(ITestStateManager stateManager, VerboseLogger logger, ContextualLogger fileHelperLogger, String kitOriginPath, String configTestDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, C runConfiguration) throws IOException, FileNotFoundException, InterruptedException;
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/ClientRunner.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ClientRunner.java
@@ -142,6 +142,21 @@ public class ClientRunner extends Thread {
     return result;
   }
 
+  /**
+   * Called to force the client process to terminate and then wait for the thread managing the runner to exit.
+   */
+  public void forceTerminate() {
+    // Force the process to terminate.
+    this.process.destroyForcibly();
+    // We still want to wait for the thread managing the runner to terminate gracefully.
+    try {
+      this.join();
+    } catch (InterruptedException e) {
+      // This is really not expected since this is already in the interruption path.
+      Assert.unexpected(e);
+    }
+  }
+
   private void setupStandardLogFiles() throws FileNotFoundException {
     Assert.assertNull(this.stdoutLog);
     Assert.assertNull(this.stderrLog);

--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -41,7 +41,7 @@ public class CommonIdioms {
    */
   public static void installAndRunClients(ITestStateManager stateManager, VerboseLogger logger, String testParentDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, IMultiProcessControl processControl, String connectUri) throws InterruptedException, IOException, FileNotFoundException {
     InterruptableClientManager manager = new InterruptableClientManager(stateManager, logger, testParentDirectory, clientClassPath, debugOptions, clientsToCreate, testClassName, processControl, connectUri);
-    stateManager.setClientShutdown(manager);
+    stateManager.addComponentToShutDown(manager);
     manager.start();
   }
 

--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -36,9 +36,13 @@ public class CommonIdioms {
     return ReadyStripe.configureAndStartStripe(stateManager, stripeLogger, fileHelperLogger, serverInstallDirectory, stripeParentDirectory, serversToCreate, serverStartPort, serverStartNumber, isRestartable, extraJarPaths, namespaceFragment, serviceFragment);
   }
 
-  public static boolean installAndRunClients(ITestStateManager stateManager, VerboseLogger logger, String testParentDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, IMultiProcessControl processControl, String connectUri) throws InterruptedException, IOException, FileNotFoundException {
+  /**
+   * Note that the clients will be run in another thread, logging to the given logger and returning their state in stateManager.
+   */
+  public static void installAndRunClients(ITestStateManager stateManager, VerboseLogger logger, String testParentDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, IMultiProcessControl processControl, String connectUri) throws InterruptedException, IOException, FileNotFoundException {
     InterruptableClientManager manager = new InterruptableClientManager(stateManager, logger, testParentDirectory, clientClassPath, debugOptions, clientsToCreate, testClassName, processControl, connectUri);
-    return manager.runClientSequence();
+    stateManager.setClientShutdown(manager);
+    manager.start();
   }
 
   public static <T> List<T> uniquifyList(List<T> list) {

--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -37,66 +37,8 @@ public class CommonIdioms {
   }
 
   public static boolean installAndRunClients(ITestStateManager stateManager, VerboseLogger logger, String testParentDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, IMultiProcessControl processControl, String connectUri) throws InterruptedException, IOException, FileNotFoundException {
-    // All clients use the same entry-point stub.
-    String clientClassName = "org.terracotta.testing.client.TestClientStub";
-    ContextualLogger clientsLogger = new ContextualLogger(logger, "[Clients]");
-    ClientInstaller clientInstaller = new ClientInstaller(clientsLogger, processControl, testParentDirectory, clientClassPath, clientClassName, testClassName, connectUri);
-    
-    // Run the setup client, synchronously.
-    ClientRunner setupClient = clientInstaller.installClient("client_setup", "SETUP", debugOptions.setupClientPort);
-    int setupExitValue = CommonIdioms.runClientSynchronous(setupClient);
-    
-    boolean setupWasClean = (0 == setupExitValue);
-    boolean didRunCleanly = true;
-    boolean destroyWasClean = true;
-    if (setupWasClean) {
-      didRunCleanly = CommonIdioms.runTestClientsConcurrently(debugOptions, clientsToCreate, clientInstaller, didRunCleanly);
-      if (!didRunCleanly) {
-        logger.fatal("ERROR encountered in test client.  Destroy will be attempted but this is a failure");
-      }
-      
-      // Run the destroy client, synchronously.
-      ClientRunner destroyClient = clientInstaller.installClient("client_destroy", "DESTROY", debugOptions.destroyClientPort);
-      int destroyExitValue = CommonIdioms.runClientSynchronous(destroyClient);
-      destroyWasClean = (0 == destroyExitValue);
-      if (!destroyWasClean) {
-        logger.fatal("ERROR encountered in destroy.  This is a failure");
-      }
-    } else {
-      logger.fatal("FATAL ERROR IN SETUP CLIENT!  Exit code " + setupExitValue + ".  NOT running tests!");
-    }
-    return setupWasClean && didRunCleanly && destroyWasClean;
-  }
-
-  public static int runClientSynchronous(ClientRunner client) throws InterruptedException, IOException {
-    client.start();
-    client.waitForPid();
-    return client.waitForJoinResult();
-  }
-
-  public static boolean runTestClientsConcurrently(DebugOptions debugOptions, int clientsToCreate, ClientInstaller clientInstaller, boolean didRunCleanly) throws FileNotFoundException, InterruptedException, IOException {
-    // The setup was clean so run the test clients.
-    // First, install them.
-    ClientRunner[] testClients = new ClientRunner[clientsToCreate];
-    for (int i = 0; i < clientsToCreate; ++i) {
-      String clientName = "client" + i;
-      // Determine if we need a debug port set.
-      int debugPort = (0 != debugOptions.testClientsStartPort)
-          ? (debugOptions.testClientsStartPort + i)
-          : 0;
-      testClients[i] = clientInstaller.installClient(clientName, "TEST", debugPort);
-    }
-    // Now, start them.
-    for (int i = 0; i < clientsToCreate; ++i) {
-      testClients[i].start();
-      testClients[i].waitForPid();
-    }
-    // Now, wait for them.
-    for (int i = 0; i < clientsToCreate; ++i) {
-      int result = testClients[i].waitForJoinResult();
-      didRunCleanly &= (0 == result);
-    }
-    return didRunCleanly;
+    InterruptableClientManager manager = new InterruptableClientManager(stateManager, logger, testParentDirectory, clientClassPath, debugOptions, clientsToCreate, testClassName, processControl, connectUri);
+    return manager.runClientSequence();
   }
 
   public static <T> List<T> uniquifyList(List<T> list) {

--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -29,14 +29,14 @@ import org.terracotta.testing.logging.VerboseLogger;
  * It exists purely to avoid duplication.
  */
 public class CommonIdioms {
-  public static ReadyStripe setupConfigureAndStartStripe(VerboseLogger logger, ContextualLogger fileHelperLogger, String serverInstallDirectory, String testParentDirectory, int serversToCreate, int serverStartPort, int serverStartNumber, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String stripeName) throws IOException, FileNotFoundException {
+  public static ReadyStripe setupConfigureAndStartStripe(ITestStateManager stateManager, VerboseLogger logger, ContextualLogger fileHelperLogger, String serverInstallDirectory, String testParentDirectory, int serversToCreate, int serverStartPort, int serverStartNumber, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String stripeName) throws IOException, FileNotFoundException {
     ContextualLogger stripeLogger = new ContextualLogger(logger, "[" + stripeName + "]");
     // We want to create a sub-directory per-stripe.
     String stripeParentDirectory = FileHelpers.createTempEmptyDirectory(testParentDirectory, stripeName);
-    return ReadyStripe.configureAndStartStripe(stripeLogger, fileHelperLogger, serverInstallDirectory, stripeParentDirectory, serversToCreate, serverStartPort, serverStartNumber, isRestartable, extraJarPaths, namespaceFragment, serviceFragment);
+    return ReadyStripe.configureAndStartStripe(stateManager, stripeLogger, fileHelperLogger, serverInstallDirectory, stripeParentDirectory, serversToCreate, serverStartPort, serverStartNumber, isRestartable, extraJarPaths, namespaceFragment, serviceFragment);
   }
 
-  public static boolean installAndRunClients(VerboseLogger logger, String testParentDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, IMultiProcessControl processControl, String connectUri) throws InterruptedException, IOException, FileNotFoundException {
+  public static boolean installAndRunClients(ITestStateManager stateManager, VerboseLogger logger, String testParentDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, IMultiProcessControl processControl, String connectUri) throws InterruptedException, IOException, FileNotFoundException {
     // All clients use the same entry-point stub.
     String clientClassName = "org.terracotta.testing.client.TestClientStub";
     ContextualLogger clientsLogger = new ContextualLogger(logger, "[Clients]");

--- a/galvan/src/main/java/org/terracotta/testing/master/IClientManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/IClientManager.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.master;
+
+
+/**
+ * An interface implemented by a component which manages the client processes, in a test.  This can be used by the broader
+ * harness state logic to force the clients to terminate, in the case of an unexpected kind of failure (server crash, for
+ * example).
+ */
+public interface IClientManager {
+  public void forceTerminate();
+}

--- a/galvan/src/main/java/org/terracotta/testing/master/IComponentManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/IComponentManager.java
@@ -17,10 +17,13 @@ package org.terracotta.testing.master;
 
 
 /**
- * An interface implemented by a component which manages the client processes, in a test.  This can be used by the broader
- * harness state logic to force the clients to terminate, in the case of an unexpected kind of failure (server crash, for
- * example).
+ * The interface implemented by components which can be force terminated by an ITestStateManager implementation.
  */
-public interface IClientManager {
-  public void forceTerminate();
+public interface IComponentManager {
+  /**
+   * Terminates the underlying component's asynchronous or background tasks.
+   * Note that this could be called after these tasks have naturally terminated so an implementation must be able to handle
+   * this case.
+   */
+  public void forceTerminateComponent();
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/ITestStateManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ITestStateManager.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.master;
+
+
+/**
+ * This interface exposes the abstract ability for different parts of the harness to register for shutdown treatment but
+ * also set the state of entire test run to pass or fail.
+ * Note that the test will be considered a failure if any single part fails, no matter whether or not the pass was set.
+ * This means that an unexpected server crash, after the test passed, would still count as a failure.
+ */
+public interface ITestStateManager {
+  public void testDidPass();
+
+  public void testDidFail();
+
+  public void setShutdownControl(IMultiProcessControl processControl);
+
+  public void setClientShutdown(IClientManager clientManager);
+}

--- a/galvan/src/main/java/org/terracotta/testing/master/ITestStateManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ITestStateManager.java
@@ -27,7 +27,5 @@ public interface ITestStateManager {
 
   public void testDidFail();
 
-  public void setShutdownControl(IMultiProcessControl processControl);
-
-  public void setClientShutdown(IClientManager clientManager);
+  public void addComponentToShutDown(IComponentManager componentManager);
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
@@ -28,7 +28,7 @@ import org.terracotta.testing.logging.VerboseLogger;
  * to stop.
  * It extends Thread since it is just an additional helper to coordinate external interruption.
  */
-public class InterruptableClientManager extends Thread implements IClientManager {
+public class InterruptableClientManager extends Thread implements IComponentManager {
   private final ITestStateManager stateManager;
   private final VerboseLogger logger;
   private final String testParentDirectory;
@@ -53,7 +53,7 @@ public class InterruptableClientManager extends Thread implements IClientManager
   }
 
   @Override
-  public void forceTerminate() {
+  public void forceTerminateComponent() {
     // We need to set that an interrupt is requested in order for our asserts, within, to trigger.
     this.interruptRequested = true;
     // We now interrupt the thread, which should cause it to shut everything down, forcefully, and fail out.

--- a/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.master;
+
+import java.io.IOException;
+
+import org.terracotta.passthrough.Assert;
+import org.terracotta.testing.logging.ContextualLogger;
+import org.terracotta.testing.logging.VerboseLogger;
+
+
+/**
+ * A container of much of the client operation logic for a test.
+ * Note that the current state of this class is a stop-gap to transition to a different design which will do asynchronous
+ * client execution and management.
+ */
+public class InterruptableClientManager {
+  private final VerboseLogger logger;
+  private final String testParentDirectory;
+  private final String clientClassPath;
+  private final DebugOptions debugOptions;
+  private final int clientsToCreate;
+  private final String testClassName;
+  private final IMultiProcessControl processControl;
+  private final String connectUri;
+
+  public InterruptableClientManager(ITestStateManager stateManager, VerboseLogger logger, String testParentDirectory, String clientClassPath, DebugOptions debugOptions, int clientsToCreate, String testClassName, IMultiProcessControl processControl, String connectUri) {
+    this.logger = logger;
+    this.testParentDirectory = testParentDirectory;
+    this.clientClassPath = clientClassPath;
+    this.debugOptions = debugOptions;
+    this.clientsToCreate = clientsToCreate;
+    this.testClassName = testClassName;
+    this.processControl = processControl;
+    this.connectUri = connectUri;
+  }
+
+  public boolean runClientSequence() {
+    // All clients use the same entry-point stub.
+    String clientClassName = "org.terracotta.testing.client.TestClientStub";
+    ContextualLogger clientsLogger = new ContextualLogger(this.logger, "[Clients]");
+    ClientInstaller clientInstaller = new ClientInstaller(clientsLogger, this.processControl, this.testParentDirectory, this.clientClassPath, clientClassName, this.testClassName, this.connectUri);
+    
+    // Run the setup client, synchronously.
+    ClientRunner setupClient = clientInstaller.installClient("client_setup", "SETUP", this.debugOptions.setupClientPort);
+    int setupExitValue = -1;
+    try {
+      setupExitValue = runClientSynchronous(setupClient);
+    } catch (InterruptedException e) {
+      // We don't have a definition of this case.
+      Assert.unexpected(e);
+    } catch (IOException e) {
+      // We don't expect this here.
+      Assert.unexpected(e);
+    }
+    
+    boolean setupWasClean = (0 == setupExitValue);
+    boolean didRunCleanly = true;
+    boolean destroyWasClean = true;
+    if (setupWasClean) {
+      ClientRunner[] concurrentTests = installTestClients(this.debugOptions, this.clientsToCreate, clientInstaller);
+      try {
+        // Start them.
+        for (ClientRunner oneClient : concurrentTests) {
+          oneClient.start();
+          oneClient.waitForPid();
+        }
+        // Now, wait for them to finish.
+        for (ClientRunner oneClient : concurrentTests) {
+          int result = oneClient.waitForJoinResult();
+          didRunCleanly &= (0 == result);
+        }
+      } catch (InterruptedException e) {
+        // We don't have a definition of this case.
+        Assert.unexpected(e);
+      } catch (IOException e) {
+        // We don't expect this here.
+        Assert.unexpected(e);
+      }
+      if (!didRunCleanly) {
+        logger.fatal("ERROR encountered in test client.  Destroy will be attempted but this is a failure");
+      }
+      
+      // Run the destroy client, synchronously.
+      ClientRunner destroyClient = clientInstaller.installClient("client_destroy", "DESTROY", this.debugOptions.destroyClientPort);
+      int destroyExitValue = -1;
+      try {
+        destroyExitValue = runClientSynchronous(destroyClient);
+      } catch (InterruptedException e) {
+        // We don't have a definition of this case.
+        Assert.unexpected(e);
+      } catch (IOException e) {
+        // We don't expect this here.
+        Assert.unexpected(e);
+      }
+      destroyWasClean = (0 == destroyExitValue);
+      if (!destroyWasClean) {
+        this.logger.fatal("ERROR encountered in destroy.  This is a failure");
+      }
+    } else {
+      this.logger.fatal("FATAL ERROR IN SETUP CLIENT!  Exit code " + setupExitValue + ".  NOT running tests!");
+    }
+    return setupWasClean && didRunCleanly && destroyWasClean;
+  }
+
+  private int runClientSynchronous(ClientRunner client) throws InterruptedException, IOException {
+    client.start();
+    client.waitForPid();
+    return client.waitForJoinResult();
+  }
+
+  private ClientRunner[] installTestClients(DebugOptions debugOptions, int clientsToCreate, ClientInstaller clientInstaller) {
+    // The setup was clean so run the test clients.
+    // First, install them.
+    ClientRunner[] testClients = new ClientRunner[clientsToCreate];
+    for (int i = 0; i < clientsToCreate; ++i) {
+      String clientName = "client" + i;
+      // Determine if we need a debug port set.
+      int debugPort = (0 != debugOptions.testClientsStartPort)
+          ? (debugOptions.testClientsStartPort + i)
+          : 0;
+      testClients[i] = clientInstaller.installClient(clientName, "TEST", debugPort);
+    }
+    return testClients;
+  }
+}

--- a/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
@@ -26,7 +26,7 @@ import org.terracotta.testing.logging.ContextualLogger;
  * A helper to install, configure, and start a single stripe, along with read-only data describing how to interact with it.
  */
 public class ReadyStripe {
-  public static ReadyStripe configureAndStartStripe(ContextualLogger stripeLogger, ContextualLogger fileHelperLogger, String serverInstallDirectory, String testParentDirectory, int serversToCreate, int serverStartPort, int serverStartNumber, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment) throws IOException, FileNotFoundException {
+  public static ReadyStripe configureAndStartStripe(ITestStateManager stateManager, ContextualLogger stripeLogger, ContextualLogger fileHelperLogger, String serverInstallDirectory, String testParentDirectory, int serversToCreate, int serverStartPort, int serverStartNumber, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment) throws IOException, FileNotFoundException {
     ContextualLogger configLogger = new ContextualLogger(stripeLogger, "[ConfigBuilder] ");
     // Create the config builder.
     ConfigBuilder configBuilder = ConfigBuilder.buildStartPort(configLogger, serverStartPort);
@@ -49,7 +49,7 @@ public class ReadyStripe {
     
     // Create the process control object.
     ContextualLogger processControlLogger = new ContextualLogger(stripeLogger, "[ProcessControl] ");
-    SynchronousProcessControl processControl = new SynchronousProcessControl(processControlLogger);
+    SynchronousProcessControl processControl = new SynchronousProcessControl(stateManager, processControlLogger);
     // Register the stripe into it and start up the server in the stripe.
     installer.startServers(processControl);
     String connectUri = configBuilder.buildUri();

--- a/galvan/src/main/java/org/terracotta/testing/master/ServerInstallation.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerInstallation.java
@@ -72,7 +72,7 @@ public class ServerInstallation {
   /**
    * @return A new ServerProcess which has not yet been started.
    */
-  public ServerProcess createNewProcess() {
+  public ServerProcess createNewProcess(ITestStateManager stateManager) {
     // Assert that the config has been written to the installation (so it is complete).
     Assert.assertTrue(this.configWritten);
     // Assert that the log files have been opened.
@@ -81,7 +81,7 @@ public class ServerInstallation {
     Assert.assertNull(this.outstandingProcess);
     
     // Create the process and check it out.
-    ServerProcess process = new ServerProcess(this, this.serverName, this.serverWorkingDirectory, this.stdoutLog, this.stderrLog);
+    ServerProcess process = new ServerProcess(stateManager, this, this.serverName, this.serverWorkingDirectory, this.stdoutLog, this.stderrLog);
     this.outstandingProcess = process;
     return process;
   }

--- a/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
@@ -43,7 +43,7 @@ public class ServerProcess {
   private ServerState state;
   private boolean isScriptReady;
 
-  public ServerProcess(ServerInstallation underlyingInstallation, String serverName, File serverWorkingDirectory, FileOutputStream stdoutLog, FileOutputStream stderrLog) {
+  public ServerProcess(ITestStateManager stateManager, ServerInstallation underlyingInstallation, String serverName, File serverWorkingDirectory, FileOutputStream stdoutLog, FileOutputStream stderrLog) {
     this.underlyingInstallation = underlyingInstallation;
     this.serverName = serverName;
     this.serverWorkingDirectory = serverWorkingDirectory;

--- a/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
@@ -39,9 +39,9 @@ public class ServerProcess {
   private final File serverWorkingDirectory;
   private final FileOutputStream stdoutLog;
   private final FileOutputStream stderrLog;
-  private AnyProcess process;
   private ServerState state;
   private boolean isScriptReady;
+  private final ExitWaiter exitWaiter;
 
   public ServerProcess(ITestStateManager stateManager, ServerInstallation underlyingInstallation, String serverName, File serverWorkingDirectory, FileOutputStream stdoutLog, FileOutputStream stderrLog) {
     this.underlyingInstallation = underlyingInstallation;
@@ -51,6 +51,9 @@ public class ServerProcess {
     this.stderrLog = stderrLog;
     // Start in the unknown state and we will wait for the stream scraping to determine our actual state.
     this.state = ServerState.UNKNOWN;
+    // Because a server can crash at any time, not just when we are expecting it to, we need a thread to wait on this operation and notify stateManager if the
+    // crash was not expected.
+    this.exitWaiter = new ExitWaiter(stateManager);
   }
 
   public ServerInstallation getUnderlyingInstallation() {
@@ -89,7 +92,7 @@ public class ServerProcess {
     serverBus.on(passiveReadyName, new ActivePassiveEventWaiter(ServerState.PASSIVE));
     
     this.isScriptReady = false;
-    this.process = AnyProcess.newBuilder()
+    AnyProcess process = AnyProcess.newBuilder()
         .command("server/bin/start-tc-server.sh", "-n", this.serverName)
         .workingDir(this.serverWorkingDirectory)
         .pipeStdout(outputStream)
@@ -106,7 +109,9 @@ public class ServerProcess {
         }
       }
     }
-    return this.process.getPid();
+    // We will now hand off the process to the ExitWaiter.
+    this.exitWaiter.startBackgroundWait(process);
+    return process.getPid();
   }
 
   /**
@@ -122,15 +127,7 @@ public class ServerProcess {
   }
 
   public int stop() throws InterruptedException {
-    int retVal = -1;
-    this.process.destroy();
-    try {
-      retVal = this.process.waitFor();
-    } catch (java.util.concurrent.CancellationException e) {
-      retVal = this.process.exitValue();
-    }
-    this.process = null;
-    return retVal;
+    return this.exitWaiter.bringDownServer();
   }
 
 
@@ -154,6 +151,60 @@ public class ServerProcess {
     @Override
     public synchronized void onEvent(Event e) throws Throwable {
       ServerProcess.this.enterState(stateToEnter);
+    }
+  }
+
+  private class ExitWaiter extends Thread {
+    private final ITestStateManager stateManager;
+    private AnyProcess process;
+    private boolean isCrashExpected;
+    private int returnValue;
+    
+    public ExitWaiter(ITestStateManager stateManager) {
+      this.stateManager = stateManager;
+      this.returnValue = -1;
+    }
+    public void startBackgroundWait(AnyProcess process) {
+      Assert.assertNull(this.process);
+      this.process = process;
+      this.start();
+    }
+    @Override
+    public void run() {
+      try {
+        this.returnValue = this.process.waitFor();
+      } catch (java.util.concurrent.CancellationException e) {
+        this.returnValue = this.process.exitValue();
+      } catch (InterruptedException e) {
+        // We don't expect interruption in this part of the test - we need to wait for the termination.
+        Assert.unexpected(e);
+      }
+      // If we send the failure, we don't want to do it under lock.
+      boolean shouldSendFailure = false;
+      synchronized(this) {
+        // See if this crash was expected.
+        if (this.isCrashExpected) {
+          // This means that someone is waiting for us.
+          this.notifyAll();
+        } else {
+          // We weren't expecting this so we need to notify the stateManager.
+          shouldSendFailure = true;
+        }
+      }
+      if (shouldSendFailure) {
+        this.stateManager.testDidFail();
+      }
+    }
+    public synchronized int bringDownServer() throws InterruptedException {
+      // Mark this as expected.
+      this.isCrashExpected = true;
+      // Destroy the process.
+      this.process.destroy();
+      // Wait until we get a return value.
+      while (-1 == this.returnValue) {
+        wait();
+      }
+      return this.returnValue;
     }
   }
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/SynchronousProcessControl.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/SynchronousProcessControl.java
@@ -24,6 +24,7 @@ import org.terracotta.testing.logging.ILogger;
 
 
 public class SynchronousProcessControl implements IMultiProcessControl {
+  private final ITestStateManager stateManager;
   private final ILogger logger;
   // Note that the active may be null if we haven't yet observed a server enter the active state.
   private ServerProcess activeServer;
@@ -32,7 +33,8 @@ public class SynchronousProcessControl implements IMultiProcessControl {
   // These servers have recently been restarted so we don't yet know their states.
   private final List<ServerProcess> unknownServers = new Vector<ServerProcess>();
   
-  public SynchronousProcessControl(ILogger logger) {
+  public SynchronousProcessControl(ITestStateManager stateManager, ILogger logger) {
+    this.stateManager = stateManager;
     this.logger = logger;
   }
 
@@ -66,7 +68,7 @@ public class SynchronousProcessControl implements IMultiProcessControl {
     ServerInstallation underlyingInstallation = victim.getUnderlyingInstallation();
     underlyingInstallation.retireProcess(victim);
     victim = null;
-    ServerProcess freshProcess = underlyingInstallation.createNewProcess();
+    ServerProcess freshProcess = underlyingInstallation.createNewProcess(this.stateManager);
     
     // Start it.
     long pid = freshProcess.start();
@@ -124,7 +126,7 @@ public class SynchronousProcessControl implements IMultiProcessControl {
     this.logger.log(">>> addServerAndStart");
     // We don't want to track the actual installations, as we only need to know about them restarting a server, so just
     // create the processes.
-    ServerProcess process = installation.createNewProcess();
+    ServerProcess process = installation.createNewProcess(this.stateManager);
     // We also want to start it.
     long pid = process.start();
     this.logger.log("Server up with PID: " + pid);

--- a/galvan/src/main/java/org/terracotta/testing/master/TestStateManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/TestStateManager.java
@@ -1,0 +1,69 @@
+package org.terracotta.testing.master;
+
+import org.terracotta.testing.common.Assert;
+
+
+/**
+ * The states of the clients and servers are run in different threads and each one of those could fail for various reasons
+ * during a test run.
+ * A given test will have its respective servers and clients created before creating this object but it acts as the waiting
+ * point for the harness main thread until either a client or server fails or until the thread running the clients notifies
+ * it that the test has completed.
+ * Note that this will only be notified of those state changes which mark the test as either a pass or a fail, not any
+ * expected activities, within a test.  For example, it will not be notified that a server terminated due to a client asking
+ * it to restart, via the expected paths.  Therefore, there is no need to worry about those states, here.
+ */
+public class TestStateManager implements ITestStateManager {
+  private boolean didTestPass;
+  private boolean didTestFail;
+  private IMultiProcessControl shutdownWhenDone;
+  private IClientManager clientsToShutDown;
+
+  /**
+   * Waits until the test completes, as either a pass or a fail, blocking the calling thread.
+   * 
+   * @return True if the test passed, false if it failed.
+   */
+  public synchronized boolean waitForFinish() {
+    Assert.assertNotNull(this.shutdownWhenDone);
+    Assert.assertNotNull(this.clientsToShutDown);
+    
+    while (!this.didTestPass && !this.didTestFail) {
+      try {
+        this.wait();
+      } catch (InterruptedException e) {
+        // We don't expect this thread to be interrupted, as it is the top-most point in the test.
+        Assert.unexpected(e);
+      }
+    }
+    
+    // Stop all the servers.
+    this.shutdownWhenDone.shutDown();
+    // Stop all the clients (will have no effect unless failure).
+    this.clientsToShutDown.forceTerminate();
+    // If we set both pass and fail, this is still a fail.
+    return !this.didTestFail;
+  }
+
+  @Override
+  public synchronized void testDidPass() {
+    this.didTestPass = true;
+    notifyAll();
+  }
+
+  @Override
+  public synchronized void testDidFail() {
+    this.didTestFail = true;
+    notifyAll();
+  }
+
+  @Override
+  public synchronized void setShutdownControl(IMultiProcessControl processControl) {
+    this.shutdownWhenDone = processControl;
+  }
+
+  @Override
+  public synchronized void setClientShutdown(IClientManager clientManager) {
+    this.clientsToShutDown = clientManager;
+  }
+}


### PR DESCRIPTION
Clients are now run asynchronously while the thread executing the test waits for the client to either mark the test as passed or until some component marks it as a failure.

Marking the test as a failure now brings down all components.