### PR TITLE
Default the server's JAVA_HOME to java.home of the harness, if it isn't set

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
@@ -37,7 +37,7 @@ public class ReadyStripe {
       configBuilder.setRestartable();
     }
     // Create the stripe installer.
-    StripeInstaller installer = new StripeInstaller(fileHelperLogger, testParentDirectory, serverInstallDirectory, extraJarPaths);
+    StripeInstaller installer = new StripeInstaller(stripeLogger, fileHelperLogger, testParentDirectory, serverInstallDirectory, extraJarPaths);
     // Configure and install each server in the stripe.
     for (int i = 0; i < serversToCreate; ++i) {
       String serverName = "testServer" + (i + serverStartNumber);

--- a/galvan/src/main/java/org/terracotta/testing/master/ServerInstallation.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerInstallation.java
@@ -21,12 +21,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 import org.terracotta.testing.common.Assert;
+import org.terracotta.testing.logging.ILogger;
 
 
 /**
  * The physical representation of a server installation, on disk.  Server processes can be started from the installation.
  */
 public class ServerInstallation {
+  private final ILogger stripeLogger;
   private final String serverName;
   private final File serverWorkingDirectory;
   private FileOutputStream stdoutLog;
@@ -34,7 +36,8 @@ public class ServerInstallation {
   private boolean configWritten;
   private ServerProcess outstandingProcess;
 
-  public ServerInstallation(String serverName, File serverWorkingDirectory) {
+  public ServerInstallation(ILogger stripeLogger, String serverName, File serverWorkingDirectory) {
+    this.stripeLogger = stripeLogger;
     this.serverName = serverName;
     this.serverWorkingDirectory = serverWorkingDirectory;
   }
@@ -81,7 +84,7 @@ public class ServerInstallation {
     Assert.assertNull(this.outstandingProcess);
     
     // Create the process and check it out.
-    ServerProcess process = new ServerProcess(stateManager, this, this.serverName, this.serverWorkingDirectory, this.stdoutLog, this.stderrLog);
+    ServerProcess process = new ServerProcess(this.stripeLogger, stateManager, this, this.serverName, this.serverWorkingDirectory, this.stdoutLog, this.stderrLog);
     this.outstandingProcess = process;
     return process;
   }

--- a/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
@@ -26,6 +26,7 @@ import org.terracotta.ipceventbus.event.EventListener;
 import org.terracotta.ipceventbus.proc.AnyProcess;
 import org.terracotta.testing.common.Assert;
 import org.terracotta.testing.common.SimpleEventingStream;
+import org.terracotta.testing.logging.ILogger;
 
 
 public class ServerProcess {
@@ -43,7 +44,7 @@ public class ServerProcess {
   private boolean isScriptReady;
   private final ExitWaiter exitWaiter;
 
-  public ServerProcess(ITestStateManager stateManager, ServerInstallation underlyingInstallation, String serverName, File serverWorkingDirectory, FileOutputStream stdoutLog, FileOutputStream stderrLog) {
+  public ServerProcess(ILogger stripeLogger, ITestStateManager stateManager, ServerInstallation underlyingInstallation, String serverName, File serverWorkingDirectory, FileOutputStream stdoutLog, FileOutputStream stderrLog) {
     this.underlyingInstallation = underlyingInstallation;
     this.serverName = serverName;
     this.serverWorkingDirectory = serverWorkingDirectory;

--- a/galvan/src/main/java/org/terracotta/testing/master/StripeInstaller.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/StripeInstaller.java
@@ -28,6 +28,7 @@ import org.terracotta.testing.logging.ILogger;
  * Handles the description, installation, and start-up of a stripe of servers in a cluster.
  */
 public class StripeInstaller {
+  private final ILogger stripeLogger;
   private final ILogger fileHelperLogger;
   private final String stripeInstallDirectory;
   private final String kitOriginDirectory;
@@ -35,7 +36,8 @@ public class StripeInstaller {
   private final List<ServerInstallation> installedServers;
   private boolean isBuilt;
   
-  public StripeInstaller(ILogger fileHelperLogger, String stripeInstallDirectory, String kitOriginDirectory, List<String> extraJarPaths) {
+  public StripeInstaller(ILogger stripeLogger, ILogger fileHelperLogger, String stripeInstallDirectory, String kitOriginDirectory, List<String> extraJarPaths) {
+    this.stripeLogger = stripeLogger;
     this.fileHelperLogger = fileHelperLogger;
     this.stripeInstallDirectory = stripeInstallDirectory;
     this.kitOriginDirectory = kitOriginDirectory;
@@ -48,7 +50,7 @@ public class StripeInstaller {
     Assert.assertFalse(this.isBuilt);
     String installPath = FileHelpers.createTempCopyOfDirectory(this.fileHelperLogger, this.stripeInstallDirectory, serverName, this.kitOriginDirectory);
     FileHelpers.copyJarsToServer(this.fileHelperLogger, installPath, this.extraJarPaths);
-    ServerInstallation installation = new ServerInstallation(serverName, new File(installPath));
+    ServerInstallation installation = new ServerInstallation(this.stripeLogger, serverName, new File(installPath));
     installation.openStandardLogFiles();
     this.installedServers.add(installation);
   }


### PR DESCRIPTION
I can't create an environment where I can observe the problem you were seeing but I know that you had a test which exposed this, in your IDE.  Can you verify that this resolves the problem and then merge if it does?