### PR TITLE
Fix #18: Pass client test environment data from harness into client process

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/client/ClientTestEnvironment.java
+++ b/galvan/src/main/java/org/terracotta/testing/client/ClientTestEnvironment.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.client;
+
+import org.terracotta.passthrough.IClientTestEnvironment;
+
+
+public class ClientTestEnvironment implements IClientTestEnvironment {
+  private final String clusterUri;
+  private final int totalClientCount;
+  private final int thisClientIndex;
+
+  public ClientTestEnvironment(String clusterUri, int totalClientCount, int thisClientIndex) {
+    this.clusterUri = clusterUri;
+    this.totalClientCount = totalClientCount;
+    this.thisClientIndex = thisClientIndex;
+  }
+
+  @Override
+  public String getClusterUri() {
+    return this.clusterUri;
+  }
+
+  @Override
+  public int getTotalClientCount() {
+    return this.totalClientCount;
+  }
+
+  @Override
+  public int getThisClientIndex() {
+    return this.thisClientIndex;
+  }
+}

--- a/galvan/src/main/java/org/terracotta/testing/master/ClientInstaller.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ClientInstaller.java
@@ -45,10 +45,10 @@ public class ClientInstaller {
     this.stripeUri = stripeUri;
   }
   
-  public ClientRunner installClient(String clientName, String clientTask, int debugPort) {
+  public ClientRunner installClient(String clientName, String clientTask, int debugPort, int totalClientCount, int thisClientIndex) {
     String clientWorkingDirectory = FileHelpers.createTempEmptyDirectory(this.testParentDirectory, clientName);
     VerboseManager clientVerboseManager = this.clientsVerboseManager.createComponentManager("[" + clientTask + "]");
-    return new ClientRunner(clientVerboseManager, this.control, new File(clientWorkingDirectory), this.clientAbsoluteClassPath, this.clientClassName, clientTask, this.testClassName, this.stripeUri, debugPort);
+    return new ClientRunner(clientVerboseManager, this.control, new File(clientWorkingDirectory), this.clientAbsoluteClassPath, this.clientClassName, clientTask, this.testClassName, this.stripeUri, debugPort, totalClientCount, thisClientIndex);
   }
   
   

--- a/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
@@ -70,7 +70,7 @@ public class InterruptableClientManager extends Thread implements IComponentMana
     ContextualLogger harnessLogger = clientsVerboseManager.createHarnessLogger();
     
     // Run the setup client, synchronously.
-    ClientRunner setupClient = clientInstaller.installClient("client_setup", "SETUP", this.debugOptions.setupClientDebugPort);
+    ClientRunner setupClient = clientInstaller.installClient("client_setup", "SETUP", this.debugOptions.setupClientDebugPort, this.clientsToCreate, 0);
     try {
       setupClient.openStandardLogFiles();
     } catch (IOException e) {
@@ -144,7 +144,7 @@ public class InterruptableClientManager extends Thread implements IComponentMana
       }
       
       // Run the destroy client, synchronously.
-      ClientRunner destroyClient = clientInstaller.installClient("client_destroy", "DESTROY", this.debugOptions.destroyClientDebugPort);
+      ClientRunner destroyClient = clientInstaller.installClient("client_destroy", "DESTROY", this.debugOptions.destroyClientDebugPort, this.clientsToCreate, 0);
       try {
         destroyClient.openStandardLogFiles();
       } catch (IOException e) {
@@ -201,7 +201,7 @@ public class InterruptableClientManager extends Thread implements IComponentMana
       int debugPort = (0 != debugOptions.testClientDebugPortStart)
           ? (debugOptions.testClientDebugPortStart + i)
           : 0;
-      testClients[i] = clientInstaller.installClient(clientName, "TEST", debugPort);
+      testClients[i] = clientInstaller.installClient(clientName, "TEST", debugPort, clientsToCreate, i);
     }
     return testClients;
   }


### PR DESCRIPTION
-this changes the multi-process bridge between ClientRunner and TestClientStub to now pass this data into the inferior process
-this new information is the total number of clients in the test as well as the current client index
-the data is provided in all cases of clients so even things like SETUP and DESTROY clients get this information (they are always index 0)