### PR TITLE
ipc-eventbus 1.0.1 (release)

### DIFF
--- a/galvan-support/pom.xml
+++ b/galvan-support/pom.xml
@@ -42,7 +42,7 @@ limitations under the License.
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>ipc-eventbus</artifactId>
-      <version>1.0.1-SNAPSHOT</version>
+      <version>1.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.terracotta</groupId>


### PR DESCRIPTION
`1.0.1` is released since October: You can point to it ;-)