### PR TITLE
Clients can now fail, individually, to bring down the test

### DIFF
--- a/galvan-support/pom.xml
+++ b/galvan-support/pom.xml
@@ -120,6 +120,7 @@ limitations under the License.
         <configuration>
           <systemPropertyVariables>
             <kitInstallationPath>${kitUnzipLocation}/terracotta-5.0.0-SNAPSHOT</kitInstallationPath>
+            <kitTestDirectory>${project.build.testOutputDirectory}/testing_directory</kitTestDirectory>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/galvan-support/src/test/java/org/terracotta/testing/support/CrashAndHangClientsIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/support/CrashAndHangClientsIT.java
@@ -1,0 +1,50 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.terracotta.testing.support;
+
+import org.junit.Assert;
+import org.terracotta.connection.Connection;
+import org.terracotta.passthrough.IClientTestEnvironment;
+import org.terracotta.passthrough.IClusterControl;
+
+
+/**
+ * This test tries to expose a failure case which we sometimes see in actual usage:
+ * -clients A and B are running a test
+ * -client A blocks on client B performing some action
+ * -client B crashes before this action is taken
+ * 
+ * The Galvan framework needs to detect that a single client crashed and bring down the rest of the processes, in response.
+ */
+public class CrashAndHangClientsIT extends MultiProcessGalvanTest {
+  @Override
+  public int getClientsToStart() {
+    return 2;
+  }
+
+  @Override
+  public void interpretResult(Throwable error) throws Throwable {
+    // We are expecting an error, so throw if it is missing.
+    if (null == error) {
+      throw new Exception("Test should have failed");
+    }
+  }
+
+  @Override
+  public void runTest(IClientTestEnvironment env, IClusterControl control, Connection connection) throws Throwable {
+    int clientIndex = env.getThisClientIndex();
+    System.out.println("Running client: " + clientIndex);
+    if (0 == clientIndex) {
+      // We will get index 0 to hang, since any sort of "walk the clients" solutions will get stuck on the earlier clients.
+      synchronized(this) {
+        wait();
+      }
+    } else {
+      // Crash the other client (the framework should see this and bring down the test).
+      Assert.fail();
+    }
+  }
+}

--- a/galvan-support/src/test/java/org/terracotta/testing/support/MultiProcessGalvanTest.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/support/MultiProcessGalvanTest.java
@@ -1,0 +1,74 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.terracotta.testing.support;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.terracotta.connection.Connection;
+import org.terracotta.passthrough.IClientTestEnvironment;
+import org.terracotta.passthrough.IClusterControl;
+import org.terracotta.passthrough.ICommonTest;
+import org.terracotta.testing.api.BasicTestClusterConfiguration;
+import org.terracotta.testing.api.ITestMaster;
+
+
+/**
+ * A class to test some of Galvan's basic functionality when running multi-process tests.
+ * Tests which want to interact with galvan from the perspective of a running client, can implement this abstract class in order to do so.
+ */
+public abstract class MultiProcessGalvanTest extends BasicHarnessTest implements ITestMaster<BasicTestClusterConfiguration>, ICommonTest {
+  public MultiProcessGalvanTest() {
+    this.setName(this.getClass().getSimpleName());
+  }
+
+  @Override
+  public String getConfigNamespaceSnippet() {
+    return "";
+  }
+
+  @Override
+  public List<String> getExtraServerJarPaths() {
+    // We expect the client code to be in the same location as the harness.
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String getServiceConfigXMLSnippet() {
+    return "";
+  }
+
+  @Override
+  public String getTestClassName() {
+    return this.getClass().getCanonicalName();
+  }
+
+  @Override
+  public boolean isRestartable() {
+    return false;
+  }
+
+  @Override
+  public List<BasicTestClusterConfiguration> getRunConfigurations() {
+    return Collections.singletonList(new BasicTestClusterConfiguration("Test", 1));
+  }
+
+
+  @Override
+  public ITestMaster<BasicTestClusterConfiguration> getTestMaster() {
+    return this;
+  }
+
+  @Override
+  public void runSetup(IClientTestEnvironment env, IClusterControl control, Connection connection) {
+    // These tests generally don't care about this.
+  }
+
+  @Override
+  public void runDestroy(IClientTestEnvironment env, IClusterControl control, Connection connection) {
+    // These tests generally don't care about this.
+  }
+}

--- a/galvan-support/src/test/java/org/terracotta/testing/support/SimpleClientStartUpIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/support/SimpleClientStartUpIT.java
@@ -1,0 +1,27 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.terracotta.testing.support;
+
+import org.terracotta.connection.Connection;
+import org.terracotta.passthrough.IClientTestEnvironment;
+import org.terracotta.passthrough.IClusterControl;
+
+
+/**
+ * A trivial test which just starts 2 clients, which do nothing and exit.  No exceptions are expected.
+ */
+public class SimpleClientStartUpIT extends MultiProcessGalvanTest {
+  @Override
+  public int getClientsToStart() {
+    return 2;
+  }
+
+  @Override
+  public void runTest(IClientTestEnvironment env, IClusterControl control, Connection connection) throws Throwable {
+    int clientIndex = env.getThisClientIndex();
+    System.out.println("Running in client: " + clientIndex);
+  }
+}

--- a/galvan/src/main/java/org/terracotta/testing/master/ClientRunner.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ClientRunner.java
@@ -56,7 +56,6 @@ public class ClientRunner extends Thread {
   
   // Data which we need to pass back to the other thread.
   private Object waitMonitor = new Object();
-  private FileNotFoundException setupFilesException;
   private long pid = -1;
   private int result = -1;
 
@@ -133,33 +132,24 @@ public class ClientRunner extends Thread {
     this.stderrLog = null;
   }
 
-  public long waitForPid() throws FileNotFoundException, InterruptedException {
+  public long waitForPid() throws InterruptedException {
     long pid = -1;
     synchronized(this.waitMonitor) {
-      while ((-1 == this.pid) && (null == this.setupFilesException)) {
+      while (-1 == this.pid) {
         this.waitMonitor.wait();
       }
-      if (null != this.setupFilesException) {
-        throw this.setupFilesException;
-      } else {
-        pid = this.pid;
-      }
+      pid = this.pid;
     }
     // Report our PID.
     this.harnessLogger.output("PID: " + pid);
     return pid;
   }
 
-  public int waitForJoinResult() throws FileNotFoundException, InterruptedException {
+  public int waitForJoinResult() throws InterruptedException {
     // We can just join on the thread and then read the state without the waitMonitor.
     this.join();
     // Now, read the result.
-    int result = -1;
-    if (null != this.setupFilesException) {
-      throw this.setupFilesException;
-    } else {
-      result = this.result;
-    }
+    int result = this.result;
     if (0 == result) {
       this.harnessLogger.output("Return value (normal): " + result);
     } else {

--- a/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.testing.master;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.terracotta.passthrough.Assert;
@@ -87,7 +88,7 @@ public class InterruptableClientManager extends Thread implements IComponentMana
       setupClient.forceTerminate();
       // Mark this as a failure so we fall out.
       setupExitValue = -1;
-    } catch (IOException e) {
+    } catch (FileNotFoundException e) {
       // We don't expect this here.
       Assert.unexpected(e);
     }
@@ -135,7 +136,7 @@ public class InterruptableClientManager extends Thread implements IComponentMana
         }
         // Mark this as a failure so we fall out.
         didRunCleanly = false;
-      } catch (IOException e) {
+      } catch (FileNotFoundException e) {
         // We don't expect this here.
         Assert.unexpected(e);
       }
@@ -161,7 +162,7 @@ public class InterruptableClientManager extends Thread implements IComponentMana
         destroyClient.forceTerminate();
         // Mark this as a failure so we fall out.
         destroyExitValue = -1;
-      } catch (IOException e) {
+      } catch (FileNotFoundException e) {
         // We don't expect this here.
         Assert.unexpected(e);
       }
@@ -185,7 +186,7 @@ public class InterruptableClientManager extends Thread implements IComponentMana
     }
   }
 
-  private int runClientSynchronous(ClientRunner client) throws InterruptedException, IOException {
+  private int runClientSynchronous(ClientRunner client) throws InterruptedException, FileNotFoundException {
     client.start();
     client.waitForPid();
     return client.waitForJoinResult();

--- a/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
@@ -15,7 +15,6 @@
  */
 package org.terracotta.testing.master;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.terracotta.passthrough.Assert;
@@ -88,9 +87,6 @@ public class InterruptableClientManager extends Thread implements IComponentMana
       setupClient.forceTerminate();
       // Mark this as a failure so we fall out.
       setupExitValue = -1;
-    } catch (FileNotFoundException e) {
-      // We don't expect this here.
-      Assert.unexpected(e);
     }
     try {
       setupClient.closeStandardLogFiles();
@@ -136,9 +132,6 @@ public class InterruptableClientManager extends Thread implements IComponentMana
         }
         // Mark this as a failure so we fall out.
         didRunCleanly = false;
-      } catch (FileNotFoundException e) {
-        // We don't expect this here.
-        Assert.unexpected(e);
       }
       if (!didRunCleanly) {
         harnessLogger.error("ERROR encountered in test client.  Destroy will be attempted but this is a failure");
@@ -162,9 +155,6 @@ public class InterruptableClientManager extends Thread implements IComponentMana
         destroyClient.forceTerminate();
         // Mark this as a failure so we fall out.
         destroyExitValue = -1;
-      } catch (FileNotFoundException e) {
-        // We don't expect this here.
-        Assert.unexpected(e);
       }
       try {
         destroyClient.closeStandardLogFiles();
@@ -186,7 +176,7 @@ public class InterruptableClientManager extends Thread implements IComponentMana
     }
   }
 
-  private int runClientSynchronous(ClientRunner client) throws InterruptedException, FileNotFoundException {
+  private int runClientSynchronous(ClientRunner client) throws InterruptedException {
     client.start();
     client.waitForPid();
     return client.waitForJoinResult();

--- a/galvan/src/main/java/org/terracotta/testing/support/AbstractHarnessRunner.java
+++ b/galvan/src/main/java/org/terracotta/testing/support/AbstractHarnessRunner.java
@@ -94,12 +94,14 @@ public abstract class AbstractHarnessRunner<C extends ITestClusterConfiguration>
       error = e;
     }
     // Determine how to handle the result.
-    if (null == error) {
+    try {
+      this.testCase.interpretResult(error);
+      
       // Success.
       notifier.fireTestFinished(testDescription);
-    } else {
+    } catch (Throwable t) {
       // Failure.
-      notifier.fireTestFailure(new Failure(testDescription, error));
+      notifier.fireTestFailure(new Failure(testDescription, t));
     }
   }
 

--- a/galvan/src/main/java/org/terracotta/testing/support/AbstractHarnessTest.java
+++ b/galvan/src/main/java/org/terracotta/testing/support/AbstractHarnessTest.java
@@ -23,4 +23,19 @@ import junit.framework.TestCase;
 
 public abstract class AbstractHarnessTest<C extends ITestClusterConfiguration> extends TestCase {
   public abstract ITestMaster<C> getTestMaster();
+
+  /**
+   * Called when a test is finished, passing in an error, if there was one.
+   * The implementation can return (implying this was a "pass"), or throw something (implying this was a "failure").
+   * 
+   * The default implementation merely re-throws the given error, assuming that most tests are looking for successful runs.
+   * 
+   * @param error An error describing the failure, or null if the test passed
+   * @throws Throwable An exception thrown to describe the failure, not thrown on a pass
+   */
+  public void interpretResult(Throwable error) throws Throwable {
+    if (null != error) {
+      throw error;
+    }
+  }
 }


### PR DESCRIPTION
This resolves the problem where a hanging client can hang the test, even though another client has already failed.

This also introduces a new testing mechanism for Galvan, internally, and introduces tests which demonstrate the normal behavior, as well as this failure scenario.