### PR TITLE
Create harness shepherding thread to shut down the test in asynchronous failures

### DIFF
--- a/galvan-support/src/test/java/org/terracotta/testing/rules/CorruptConfigWithClassRuleIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/rules/CorruptConfigWithClassRuleIT.java
@@ -1,0 +1,48 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.terracotta.testing.rules;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Properties;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.terracotta.connection.Connection;
+import org.terracotta.connection.ConnectionException;
+import org.terracotta.connection.ConnectionFactory;
+
+
+/**
+ * This test is effectly the same as BasicExternalClusterClassRuleIT except that it deliberately corrupts the server config
+ * so that the server will fail to start.  It then runs 2 tests on the same class rule to ensure that re-using this broken
+ * cluster instance will return failure in both cases.
+ */
+public class CorruptConfigWithClassRuleIT {
+  @ClassRule
+  public static final Cluster CLUSTER = new BasicExternalCluster(new File("target/cluster"), 1, Collections.<File>emptyList(), "", "", "BOGUS<ENTITY<FRAGMENT");
+
+  @Test(expected=ConnectionException.class)
+  public void testDirectConnection() throws IOException, ConnectionException {
+    Connection connection = CLUSTER.newConnection();
+    try {
+      //do nothing
+    } finally {
+      connection.close();
+    }
+  }
+
+  @Test(expected=ConnectionException.class)
+  public void testConnectionViaURI() throws IOException, ConnectionException {
+    Connection connection = ConnectionFactory.connect(CLUSTER.getConnectionURI(), new Properties());
+    try {
+      //do nothing
+    } finally {
+      connection.close();
+    }
+  }
+}

--- a/galvan-support/src/test/java/org/terracotta/testing/rules/CorruptConfigWithClassRuleIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/rules/CorruptConfigWithClassRuleIT.java
@@ -6,7 +6,6 @@
 package org.terracotta.testing.rules;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -27,7 +26,7 @@ public class CorruptConfigWithClassRuleIT {
   public static final Cluster CLUSTER = new BasicExternalCluster(new File("target/cluster"), 1, Collections.<File>emptyList(), "", "", "BOGUS<ENTITY<FRAGMENT");
 
   @Test(expected=ConnectionException.class)
-  public void testDirectConnection() throws IOException, ConnectionException {
+  public void testDirectConnection() throws Exception {
     Connection connection = CLUSTER.newConnection();
     try {
       //do nothing
@@ -36,8 +35,14 @@ public class CorruptConfigWithClassRuleIT {
     }
   }
 
+  // We expect IllegalStateException when the active fails to come up while we are waiting for it.
+  @Test(expected=IllegalStateException.class)
+  public void testWaitForActiveCrash() throws Exception {
+    CLUSTER.getClusterControl().waitForActive();
+  }
+
   @Test(expected=ConnectionException.class)
-  public void testConnectionViaURI() throws IOException, ConnectionException {
+  public void testConnectionViaURI() throws Exception {
     Connection connection = ConnectionFactory.connect(CLUSTER.getConnectionURI(), new Properties());
     try {
       //do nothing

--- a/galvan-support/src/test/java/org/terracotta/testing/support/CorruptServerConfigIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/support/CorruptServerConfigIT.java
@@ -1,0 +1,42 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.terracotta.testing.support;
+
+import org.terracotta.connection.Connection;
+import org.terracotta.passthrough.IClientTestEnvironment;
+import org.terracotta.passthrough.IClusterControl;
+
+
+/**
+ * This test overrides the normal config options of the server, resulting in a corrupt config.  The server will fail to even
+ * start.
+ * 1 Client is started, who does nothing.
+ */
+public class CorruptServerConfigIT extends MultiProcessGalvanTest {
+  @Override
+  public int getClientsToStart() {
+    return 1;
+  }
+
+  @Override
+  public String getEntityConfigXMLSnippet() {
+    return "Bogus<String<";
+  }
+
+  @Override
+  public void interpretResult(Throwable error) throws Throwable {
+    // We are expecting an error, so throw if it is missing.
+    if (null == error) {
+      throw new Exception("Test should have failed");
+    }
+  }
+
+  @Override
+  public void runTest(IClientTestEnvironment env, IClusterControl control, Connection connection) throws Throwable {
+    int clientIndex = env.getThisClientIndex();
+    System.out.println("Running in client: " + clientIndex);
+  }
+}

--- a/galvan/src/main/java/org/terracotta/testing/master/SynchronousProcessControl.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/SynchronousProcessControl.java
@@ -182,8 +182,13 @@ public class SynchronousProcessControl implements IMultiProcessControl {
           ServerProcess passive = oldPassives.remove(0);
           waitAndPlaceServerInState(passive);
         }
-        // If there is no active at this point, we have a serious bug (this could be a race condition we haven't eliminated).
-        Assert.assertTrue(null != this.activeServer);
+        
+        // See if we are still without an active.
+        if (null == this.activeServer) {
+          // If there is no active at this point, it probably means that there is something seriously wrong with the
+          // server, such that it crashed while we were waiting for it to start.
+          throw new IllegalStateException("Active process did not appear");
+        }
       }
     }
   }


### PR DESCRIPTION
This should address the issues of hangs in testing, seen earlier in the week.