### PR TITLE
AbstractHarnessRunner now runs each test in its own sub-directory

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
@@ -58,6 +58,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     
     // Create a copy of the server installation.
     ContextualLogger fileHelperLogger = verboseManager.createFileHelpersLogger();
+    FileHelpers.ensureDirectoryExists(fileHelperLogger, environmentOptions.testParentDirectory);
     FileHelpers.cleanDirectory(fileHelperLogger, environmentOptions.testParentDirectory);
     // Put together the config for the stripe.
     String testClassName = master.getTestClassName();

--- a/galvan/src/main/java/org/terracotta/testing/master/FileHelpers.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/FileHelpers.java
@@ -105,6 +105,24 @@ public class FileHelpers {
     return targetDirectory.toAbsolutePath().toString();
   }
 
+  public static void copyJarsToServer(ContextualLogger logger, String instanceServerInstallPath, List<String> extraJarPaths) throws IOException {
+    // We know we want to copy these into plugins/lib.
+    FileSystem fileSystem = FileSystems.getDefault();
+    Path pluginsLibDirectory = fileSystem.getPath(instanceServerInstallPath, "server", "plugins", "lib");
+    // This needs to be a directory.
+    Assert.assertTrue(pluginsLibDirectory.toFile().isDirectory());
+    for (String oneJarPath : extraJarPaths) {
+      Path sourcePath = fileSystem.getPath(oneJarPath);
+      // This file must exist.
+      Assert.assertTrue(sourcePath.toFile().isFile());
+      Path targetPath = pluginsLibDirectory.resolve(sourcePath.getFileName());
+      // This must not exist.
+      logger.output("Installing JAR: " + targetPath + "...");
+      Assert.assertFalse(targetPath.toFile().exists());
+      Files.copy(sourcePath, targetPath);
+      logger.output("Done");
+    }
+  }
 
   private static class DirectoryCopier implements FileVisitor<Path> {
     private final ContextualLogger logger;
@@ -155,26 +173,6 @@ public class FileHelpers {
         this.currentTargetDirectory = this.currentTargetDirectory.getParent();
       }
       return FileVisitResult.CONTINUE;
-    }
-  }
-
-
-  public static void copyJarsToServer(ContextualLogger logger, String instanceServerInstallPath, List<String> extraJarPaths) throws IOException {
-    // We know we want to copy these into plugins/lib.
-    FileSystem fileSystem = FileSystems.getDefault();
-    Path pluginsLibDirectory = fileSystem.getPath(instanceServerInstallPath, "server", "plugins", "lib");
-    // This needs to be a directory.
-    Assert.assertTrue(pluginsLibDirectory.toFile().isDirectory());
-    for (String oneJarPath : extraJarPaths) {
-      Path sourcePath = fileSystem.getPath(oneJarPath);
-      // This file must exist.
-      Assert.assertTrue(sourcePath.toFile().isFile());
-      Path targetPath = pluginsLibDirectory.resolve(sourcePath.getFileName());
-      // This must not exist.
-      logger.output("Installing JAR: " + targetPath + "...");
-      Assert.assertFalse(targetPath.toFile().exists());
-      Files.copy(sourcePath, targetPath);
-      logger.output("Done");
     }
   }
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/FileHelpers.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/FileHelpers.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.testing.master;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -124,6 +125,13 @@ public class FileHelpers {
     }
   }
 
+  public static void ensureDirectoryExists(ContextualLogger logger, String directoryPath) {
+    logger.output(" Ensure directory: " + directoryPath);
+    File asFile = new File(directoryPath);
+    ensureExistsRecursive(asFile);
+  }
+
+
   private static class DirectoryCopier implements FileVisitor<Path> {
     private final ContextualLogger logger;
     private final Path targetDirectory;
@@ -173,6 +181,18 @@ public class FileHelpers {
         this.currentTargetDirectory = this.currentTargetDirectory.getParent();
       }
       return FileVisitResult.CONTINUE;
+    }
+  }
+
+
+  private static void ensureExistsRecursive(File directoryToCreate) {
+    if (directoryToCreate.exists()) {
+      // This exists so it must be a directory.
+      Assert.assertTrue(directoryToCreate.isDirectory());
+    } else {
+      ensureExistsRecursive(directoryToCreate.getParentFile());
+      boolean didMake = directoryToCreate.mkdir();
+      Assert.assertTrue(didMake);
     }
   }
 }

--- a/galvan/src/main/java/org/terracotta/testing/support/AbstractHarnessRunner.java
+++ b/galvan/src/main/java/org/terracotta/testing/support/AbstractHarnessRunner.java
@@ -15,6 +15,7 @@
  */
 package org.terracotta.testing.support;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
@@ -52,10 +53,12 @@ public abstract class AbstractHarnessRunner<C extends ITestClusterConfiguration>
     notifier.fireTestStarted(testDescription);
     
     // Get the system properties we require.
+    String allTestParentDirectory = System.getProperty("kitTestDirectory");
+    String thisTestName = this.testCase.getName();
     EnvironmentOptions environmentOptions = new EnvironmentOptions();
     environmentOptions.clientClassPath = System.getProperty("java.class.path");
     environmentOptions.serverInstallDirectory = System.getProperty("kitInstallationPath");
-    environmentOptions.testParentDirectory = System.getProperty("kitTestDirectory");
+    environmentOptions.testParentDirectory = allTestParentDirectory + File.separator + thisTestName;
     Assert.assertTrue(environmentOptions.isValid());
     
     // Get the test master implementation.


### PR DESCRIPTION
This should address intermittent failures seen in concurrent test runs where the configurations have colliding names.