### PR TITLE
Use -e instead of -a when running ps

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
@@ -273,7 +273,7 @@ public class ServerProcess {
 
     private void killProcessUnix() throws InterruptedException, IOException {
       // We will look up our eyecatcher
-      Process ps = Runtime.getRuntime().exec("ps -aww -o pid,command");
+      Process ps = Runtime.getRuntime().exec("ps -eww -o pid,command");
       BufferedReader outputReader = new BufferedReader(new InputStreamReader(ps.getInputStream()));
       int result = ps.waitFor();
       Assert.assertTrue(0 == result);


### PR DESCRIPTION
-this appears to be more portable as error return values where created on some Linux invocations when -a was used