### PR TITLE
Fix #57: Setup/Destroy clients know the total client count

### DIFF
--- a/galvan-support/src/main/java/org/terracotta/testing/master/BasicClientArgumentBuilder.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/master/BasicClientArgumentBuilder.java
@@ -38,8 +38,8 @@ public class BasicClientArgumentBuilder implements IClientArgumentBuilder {
   }
 
   @Override
-  public List<String> getArgumentsForSetupRun(String connectUri) {
-    return buildList("SETUP", connectUri, 1, 0);
+  public List<String> getArgumentsForSetupRun(String connectUri, int totalClientCount) {
+    return buildList("SETUP", connectUri, totalClientCount, 0);
   }
 
   @Override
@@ -48,8 +48,8 @@ public class BasicClientArgumentBuilder implements IClientArgumentBuilder {
   }
 
   @Override
-  public List<String> getArgumentsForDestroyRun(String connectUri) {
-    return buildList("DESTROY", connectUri, 1, 0);
+  public List<String> getArgumentsForDestroyRun(String connectUri, int totalClientCount) {
+    return buildList("DESTROY", connectUri, totalClientCount, 0);
   }
 
 

--- a/galvan-support/src/test/java/org/terracotta/testing/support/SimpleClientStartUpIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/support/SimpleClientStartUpIT.java
@@ -5,23 +5,43 @@
  */
 package org.terracotta.testing.support;
 
+import org.junit.Assert;
 import org.terracotta.connection.Connection;
 import org.terracotta.passthrough.IClientTestEnvironment;
 import org.terracotta.passthrough.IClusterControl;
 
 
 /**
- * A trivial test which just starts 2 clients, which do nothing and exit.  No exceptions are expected.
+ * A trivial test which just starts 2 clients which verify client counts, and exit.  No exceptions are expected.
  */
 public class SimpleClientStartUpIT extends MultiProcessGalvanTest {
+  private static final int CLIENT_COUNT = 2;
+
   @Override
   public int getClientsToStart() {
-    return 2;
+    return CLIENT_COUNT;
+  }
+
+  @Override
+  public void runSetup(IClientTestEnvironment env, IClusterControl control, Connection connection) {
+    // Just verify that the client counts are expected.
+    Assert.assertTrue(CLIENT_COUNT == env.getTotalClientCount());
+    Assert.assertTrue(0 == env.getThisClientIndex());
+  }
+
+  @Override
+  public void runDestroy(IClientTestEnvironment env, IClusterControl control, Connection connection) {
+    // These tests generally don't care about this.
+    Assert.assertTrue(CLIENT_COUNT == env.getTotalClientCount());
+    Assert.assertTrue(0 == env.getThisClientIndex());
   }
 
   @Override
   public void runTest(IClientTestEnvironment env, IClusterControl control, Connection connection) throws Throwable {
     int clientIndex = env.getThisClientIndex();
+    Assert.assertTrue(clientIndex >= 0);
+    Assert.assertTrue(clientIndex < CLIENT_COUNT);
+    Assert.assertTrue(CLIENT_COUNT == env.getTotalClientCount());
     System.out.println("Running in client: " + clientIndex);
   }
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/IClientArgumentBuilder.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/IClientArgumentBuilder.java
@@ -32,9 +32,10 @@ public interface IClientArgumentBuilder {
    * Creates the argument list for a "setup" client run.
    * 
    * @param connectUri The URI of the test stripe
+   * @param totalClientCount The total number of test clients which will run the test, concurrently
    * @return The list of arguments to pass to the client main
    */
-  public List<String> getArgumentsForSetupRun(String connectUri);
+  public List<String> getArgumentsForSetupRun(String connectUri, int totalClientCount);
 
   /**
    * Creates the argument list for a regular "test" client run.
@@ -50,7 +51,8 @@ public interface IClientArgumentBuilder {
    * Creates the argument list for a "destroy" client run.
    * 
    * @param connectUri The URI of the test stripe
+   * @param totalClientCount The total number of test clients which will run the test, concurrently
    * @return The list of arguments to pass to the client main
    */
-  public List<String> getArgumentsForDestroyRun(String connectUri);
+  public List<String> getArgumentsForDestroyRun(String connectUri, int totalClientCount);
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/InterruptableClientManager.java
@@ -78,7 +78,7 @@ public class InterruptableClientManager extends Thread implements IComponentMana
     ContextualLogger harnessLogger = clientsVerboseManager.createHarnessLogger();
     
     // Run the setup client, synchronously.
-    List<String> extraSetupArguments = this.clientArgumentBuilder.getArgumentsForSetupRun(this.connectUri);
+    List<String> extraSetupArguments = this.clientArgumentBuilder.getArgumentsForSetupRun(this.connectUri, this.clientsToCreate);
     ClientRunner setupClient = clientInstaller.installClient("client_setup", this.setupClientDebugPort, extraSetupArguments);
     int setupExitValue = runClientLifeCycle(setupClient);
     
@@ -125,7 +125,7 @@ public class InterruptableClientManager extends Thread implements IComponentMana
       }
       
       // Run the destroy client, synchronously.
-      List<String> extraDestroyArguments = this.clientArgumentBuilder.getArgumentsForDestroyRun(this.connectUri);
+      List<String> extraDestroyArguments = this.clientArgumentBuilder.getArgumentsForDestroyRun(this.connectUri, this.clientsToCreate);
       ClientRunner destroyClient = clientInstaller.installClient("client_destroy", this.destroyClientDebugPort, extraDestroyArguments);
       int destroyExitValue = runClientLifeCycle(destroyClient);
       destroyWasClean = (0 == destroyExitValue);


### PR DESCRIPTION
-this removes the special-case where the setup/destroy clients didn't know the number of clients which would run the test (which was problematic since the setup would often need this number in order to setup test resources)
-augmented the SimpleClientStartUpIT test to verify these values

NOTE:  This won't be exposed until the next release (which will likely be later today).