### PR TITLE
Fix #68: Clients should be shut-down first, on failure

### DIFF
--- a/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
@@ -53,11 +53,12 @@ public class BasicHarnessEntry extends AbstractHarnessEntry<BasicTestClusterConf
     Assert.assertTrue(null != connectUri);
     
     // Register to shut down the process control (the servers in the stripe) once the test has passed/failed.
+    // Note that we want to shut down servers last.
     stateManager.addComponentToShutDown(new IComponentManager() {
       @Override
       public void forceTerminateComponent() {
         processControl.terminateAllServers();
-      }});
+      }}, false);
     
     // The cluster is now running so install and run the clients.
     CommonIdioms.ClientsConfiguration clientsConfiguration = new CommonIdioms.ClientsConfiguration();

--- a/galvan-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
@@ -112,12 +112,13 @@ public class BasicExternalCluster extends Cluster {
         : 0;
 
     stateManager = new TestStateManager();
+    // Note that we want to shut down servers last.
     stateManager.addComponentToShutDown(new IComponentManager() {
       @Override
       public void forceTerminateComponent() {
         cluster.stripeControl.terminateAllServers();
       }
-    });
+    }, false);
     cluster = ReadyStripe.configureAndStartStripe(stateManager, displayVerboseManager,
         serverInstallDirectory.getAbsolutePath(),
         testParentDirectory.getAbsolutePath(),

--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -39,7 +39,8 @@ public class CommonIdioms {
    */
   public static void installAndRunClients(ITestStateManager stateManager, VerboseManager verboseManager, ClientsConfiguration clientsConfiguration, IMultiProcessControl processControl) throws InterruptedException, IOException, FileNotFoundException {
     InterruptableClientManager manager = new InterruptableClientManager(stateManager, verboseManager, processControl, clientsConfiguration.testParentDirectory, clientsConfiguration.clientClassPath, clientsConfiguration.setupClientDebugPort, clientsConfiguration.destroyClientDebugPort, clientsConfiguration.testClientDebugPortStart, clientsConfiguration.clientsToCreate, clientsConfiguration.clientArgumentBuilder, clientsConfiguration.connectUri);
-    stateManager.addComponentToShutDown(manager);
+    // We want to shut down clients "first".
+    stateManager.addComponentToShutDown(manager, true);
     manager.start();
   }
 

--- a/galvan/src/main/java/org/terracotta/testing/master/ITestStateManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ITestStateManager.java
@@ -27,5 +27,11 @@ public interface ITestStateManager {
 
   public void testDidFail();
 
-  public void addComponentToShutDown(IComponentManager componentManager);
+  /**
+   * Registers a component which needs to be shut down when the test is complete.
+   * 
+   * @param componentManager The component to shut down.
+   * @param shouldPrepend True if this component should be shutdown "first", false if it can be shut down "last"
+   */
+  public void addComponentToShutDown(IComponentManager componentManager, boolean shouldPrepend);
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/TestStateManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/TestStateManager.java
@@ -61,7 +61,11 @@ public class TestStateManager implements ITestStateManager {
   }
 
   @Override
-  public synchronized void addComponentToShutDown(IComponentManager componentManager) {
-    this.componentsToShutDown.add(componentManager);
+  public synchronized void addComponentToShutDown(IComponentManager componentManager, boolean shouldPrepend) {
+    if (shouldPrepend) {
+      this.componentsToShutDown.add(0, componentManager);
+    } else {
+      this.componentsToShutDown.add(componentManager);
+    }
   }
 }


### PR DESCRIPTION
-this is mostly a work-around until a larger refactoring is done to address concerns such as #41
-it means that failures to shut-down the servers, twice, will not block the termination of outstanding clients