### PR TITLE
make sure only the console appender triggers events

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
@@ -196,7 +196,7 @@ public class ServerProcess {
     Map<String, String> eventMap = new HashMap<String, String>();
     eventMap.put("PID is", pidEventName);
     eventMap.put("Terracotta Server instance has started up as ACTIVE node", activeReadyName);
-    eventMap.put("Moved to State[ PASSIVE-STANDBY ]", passiveReadyName);
+    eventMap.put("console - Moved to State[ PASSIVE-STANDBY ]", passiveReadyName);
     eventMap.put("Restarting the server", zapEventName);
     
     // We will attach the event stream to the stdout.


### PR DESCRIPTION
If the logger is in dev mode.  All INFO level messages go to the console triggering duplicate events.  Make the passive standby trigger more specific.