### PR TITLE
Fix #76: Add .tc.dev.log4j.properties to server root

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/master/FileHelpers.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/FileHelpers.java
@@ -131,6 +131,14 @@ public class FileHelpers {
     ensureExistsRecursive(asFile);
   }
 
+  public static void touchEmptyFile(ContextualLogger logger, String parentDirectoryPath, String fileName) throws IOException {
+    File newFile = new File(parentDirectoryPath, fileName);
+    logger.output("Creating empty file: " + newFile.getAbsolutePath());
+    boolean didCreate = newFile.createNewFile();
+    // This helper has no notion of failure to create (without exception).
+    Assert.assertTrue(didCreate);
+  }
+
 
   private static class DirectoryCopier implements FileVisitor<Path> {
     private final ContextualLogger logger;

--- a/galvan/src/main/java/org/terracotta/testing/master/StripeInstaller.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/StripeInstaller.java
@@ -51,10 +51,17 @@ public class StripeInstaller {
   }
   
   public void installNewServer(String serverName, int debugPort) throws IOException {
+    // Our implementation installs all servers before starting any (just an internal consistency check).
     Assert.assertFalse(this.isBuilt);
+    // Create the logger for the intallation.
     ContextualLogger fileHelperLogger = this.stripeVerboseManager.createFileHelpersLogger();
+    // Create a copy of the server for this installation.
     String installPath = FileHelpers.createTempCopyOfDirectory(fileHelperLogger, this.stripeInstallDirectory, serverName, this.kitOriginDirectory);
+    // Copy the extra jars this test needs into the new installation.
     FileHelpers.copyJarsToServer(fileHelperLogger, installPath, this.extraJarPaths);
+    // Create the empty Log4J properties file to force the server to use the expected appender so we know the shape of text to read as events.
+    FileHelpers.touchEmptyFile(fileHelperLogger, installPath, ".tc.dev.log4j.properties");
+    // Create the object representing this single installation and add it to the list for this stripe.
     ServerInstallation installation = new ServerInstallation(this.interlock, this.stateManager, this.stripeVerboseManager, serverName, new File(installPath), debugPort);
     this.installedServers.add(installation);
   }


### PR DESCRIPTION
-detecting this file (and the server root is one of the locations searched) will put the Log4J appenders into the state expected by 4082087de6e44b61999a93fd694d1c86c35ea121, no matter how the local environment is configured