### PR TITLE
Fix #78: Added serverHeapInM to CommonHarnessOptions

### DIFF
--- a/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
@@ -33,6 +33,7 @@ public class BasicHarnessEntry extends AbstractHarnessEntry<BasicTestClusterConf
     stripeConfiguration.kitOriginPath = harnessOptions.kitOriginPath;
     stripeConfiguration.testParentDirectory = harnessOptions.configTestDirectory;
     stripeConfiguration.serversToCreate = serversToCreate;
+    stripeConfiguration.serverHeapInM = harnessOptions.serverHeapInM;
     stripeConfiguration.serverStartPort = chooseRandomPort();
     stripeConfiguration.serverDebugPortStart = debugOptions.serverDebugPortStart;
     stripeConfiguration.serverStartNumber = 0;

--- a/galvan-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
@@ -120,11 +120,13 @@ public class BasicExternalCluster extends Cluster {
         : 0;
 
     stateManager = new TestStateManager();
+    // By default, we will use 128M heap size.
+    int heapInM = 128;
     interlock = new GalvanStateInterlock(verboseManager.createComponentManager("[Interlock]").createHarnessLogger(), stateManager);
     cluster = ReadyStripe.configureAndStartStripe(interlock, stateManager, displayVerboseManager,
         serverInstallDirectory.getAbsolutePath(),
         testParentDirectory.getAbsolutePath(),
-        stripeSize, serverPort, serverDebugStartPort, 0, this.isRestartable,
+        stripeSize, heapInM, serverPort, serverDebugStartPort, 0, this.isRestartable,
         serverJarPaths, namespaceFragment, serviceFragment, entityFragment);
     // Spin up an extra thread to call waitForFinish on the stateManager.
     // This is required since galvan expects that the client is running in a different thread (different process, usually)

--- a/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
@@ -136,10 +136,19 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     public String clientClassPath;
     public int clientsToCreate;
     public String testClassName;
+    public int serverHeapInM;
     public boolean isRestartable;
     public List<String> extraJarPaths;
     public String namespaceFragment;
     public String serviceFragment;
     public String entityFragment;
+    
+    /**
+     * This constructor only exists to set convenient defaults.
+     */
+    public CommonHarnessOptions() {
+      // By default, we will configure a server with a 128M heap.
+      this.serverHeapInM = 128;
+    }
   }
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -31,7 +31,7 @@ public class CommonIdioms {
     VerboseManager stripeVerboseManager = verboseManager.createComponentManager("[" + stripeConfiguration.stripeName + "]");
     // We want to create a sub-directory per-stripe.
     String stripeParentDirectory = FileHelpers.createTempEmptyDirectory(stripeConfiguration.testParentDirectory, stripeConfiguration.stripeName);
-    return ReadyStripe.configureAndStartStripe(interlock, stateManager, stripeVerboseManager, stripeConfiguration.kitOriginPath, stripeParentDirectory, stripeConfiguration.serversToCreate, stripeConfiguration.serverStartPort, stripeConfiguration.serverDebugPortStart, stripeConfiguration.serverStartNumber, stripeConfiguration.isRestartable, stripeConfiguration.extraJarPaths, stripeConfiguration.namespaceFragment, stripeConfiguration.serviceFragment, stripeConfiguration.entityFragment);
+    return ReadyStripe.configureAndStartStripe(interlock, stateManager, stripeVerboseManager, stripeConfiguration.kitOriginPath, stripeParentDirectory, stripeConfiguration.serversToCreate, stripeConfiguration.serverHeapInM, stripeConfiguration.serverStartPort, stripeConfiguration.serverDebugPortStart, stripeConfiguration.serverStartNumber, stripeConfiguration.isRestartable, stripeConfiguration.extraJarPaths, stripeConfiguration.namespaceFragment, stripeConfiguration.serviceFragment, stripeConfiguration.entityFragment);
   }
   /**
    * Note that the clients will be run in another thread, logging to the given logger and returning their state in stateManager.
@@ -61,6 +61,7 @@ public class CommonIdioms {
     public String kitOriginPath;
     public String testParentDirectory;
     public int serversToCreate;
+    public int serverHeapInM;
     public int serverStartPort;
     public int serverDebugPortStart;
     public int serverStartNumber;

--- a/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
@@ -26,7 +26,7 @@ import org.terracotta.testing.logging.VerboseManager;
  * A helper to install, configure, and start a single stripe, along with read-only data describing how to interact with it.
  */
 public class ReadyStripe {
-  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String testParentDirectory, int serversToCreate, int serverStartPort, int serverDebugPortStart, int serverStartNumber, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment) throws IOException {
+  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String testParentDirectory, int serversToCreate, int heapInM, int serverStartPort, int serverDebugPortStart, int serverStartNumber, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment) throws IOException {
     ContextualLogger configLogger = stripeVerboseManager.createComponentManager("[ConfigBuilder]").createHarnessLogger();
     // Create the config builder.
     ConfigBuilder configBuilder = ConfigBuilder.buildStartPort(configLogger, serverStartPort);
@@ -47,7 +47,7 @@ public class ReadyStripe {
           ? (serverDebugPortStart + i)
           : 0;
       configBuilder.addServer(serverName);
-      installer.installNewServer(serverName, debugPort);
+      installer.installNewServer(serverName, heapInM, debugPort);
     }
     // The config is built and stripe has been installed so write the config to the stripe.
     installer.installConfig(configBuilder.buildConfig());

--- a/galvan/src/main/java/org/terracotta/testing/master/ServerInstallation.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerInstallation.java
@@ -32,16 +32,18 @@ public class ServerInstallation {
   private final VerboseManager stripeVerboseManager;
   private final String serverName;
   private final File serverWorkingDirectory;
+  private final int heapInM;
   private final int debugPort;
   private boolean configWritten;
   private boolean hasCreatedProcess;
 
-  public ServerInstallation(GalvanStateInterlock stateInterlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverName, File serverWorkingDirectory, int debugPort) {
+  public ServerInstallation(GalvanStateInterlock stateInterlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverName, File serverWorkingDirectory, int heapInM, int debugPort) {
     this.stateInterlock = stateInterlock;
     this.stateManager = stateManager;
     this.stripeVerboseManager = stripeVerboseManager;
     this.serverName = serverName;
     this.serverWorkingDirectory = serverWorkingDirectory;
+    this.heapInM = heapInM;
     this.debugPort = debugPort;
   }
 
@@ -71,7 +73,7 @@ public class ServerInstallation {
     // Create the VerboseManager for the instance.
     VerboseManager serverVerboseManager = this.stripeVerboseManager.createComponentManager("[" + this.serverName + "]");
     // Create the process and check it out.
-    ServerProcess process = new ServerProcess(this.stateInterlock, this.stateManager, serverVerboseManager, this, this.serverName, this.serverWorkingDirectory, this.debugPort);
+    ServerProcess process = new ServerProcess(this.stateInterlock, this.stateManager, serverVerboseManager, this, this.serverName, this.serverWorkingDirectory, this.heapInM, this.debugPort);
     this.hasCreatedProcess = true;
     return process;
   }

--- a/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
@@ -46,6 +46,7 @@ public class ServerProcess {
   private final ContextualLogger harnessLogger;
   private final ContextualLogger serverLogger;
   private final String serverName;
+  private final int heapInM;
   private final int debugPort;
   private final File serverWorkingDirectory;
   private final String eyeCatcher;
@@ -60,7 +61,7 @@ public class ServerProcess {
   private OutputStream outputStream;
   private OutputStream errorStream;
 
-  public ServerProcess(GalvanStateInterlock stateInterlock, ITestStateManager stateManager, VerboseManager serverVerboseManager, ServerInstallation underlyingInstallation, String serverName, File serverWorkingDirectory, int debugPort) {
+  public ServerProcess(GalvanStateInterlock stateInterlock, ITestStateManager stateManager, VerboseManager serverVerboseManager, ServerInstallation underlyingInstallation, String serverName, File serverWorkingDirectory, int heapInM, int debugPort) {
     this.stateInterlock = stateInterlock; 
     this.stateManager = stateManager;
     // We just want to create the harness logger and the one for the inferior process but then discard the verbose manager.
@@ -68,6 +69,9 @@ public class ServerProcess {
     this.serverLogger = serverVerboseManager.createServerLogger();
     
     this.serverName = serverName;
+    // We need to specify a positive integer as the heap size.
+    Assert.assertTrue(heapInM > 0);
+    this.heapInM = heapInM;
     this.debugPort = debugPort;
     this.serverWorkingDirectory = serverWorkingDirectory;
     // Create our eye-catcher for looking up sub-processes.
@@ -161,9 +165,7 @@ public class ServerProcess {
     if (null == javaOpts) {
       javaOpts = "";
     }
-    // Note that we currently want to scale down our heap to 128M since our tests are simple.
-    // TODO:  Find a way to expose this to the test being run.
-    javaOpts += " -Xms128m -Xms128m";
+    javaOpts += " -Xms" + this.heapInM + "m -Xmx" + this.heapInM + "m";
     if (debugPort > 0) {
       // Set up the client to block while waiting for connection.
       javaOpts += " -Xdebug -Xrunjdwp:transport=dt_socket,server=y,address=" + debugPort;

--- a/galvan/src/main/java/org/terracotta/testing/master/StripeInstaller.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/StripeInstaller.java
@@ -50,7 +50,7 @@ public class StripeInstaller {
     this.installedServers = new Vector<ServerInstallation>();
   }
   
-  public void installNewServer(String serverName, int debugPort) throws IOException {
+  public void installNewServer(String serverName, int heapInM, int debugPort) throws IOException {
     // Our implementation installs all servers before starting any (just an internal consistency check).
     Assert.assertFalse(this.isBuilt);
     // Create the logger for the intallation.
@@ -62,7 +62,7 @@ public class StripeInstaller {
     // Create the empty Log4J properties file to force the server to use the expected appender so we know the shape of text to read as events.
     FileHelpers.touchEmptyFile(fileHelperLogger, installPath, ".tc.dev.log4j.properties");
     // Create the object representing this single installation and add it to the list for this stripe.
-    ServerInstallation installation = new ServerInstallation(this.interlock, this.stateManager, this.stripeVerboseManager, serverName, new File(installPath), debugPort);
+    ServerInstallation installation = new ServerInstallation(this.interlock, this.stateManager, this.stripeVerboseManager, serverName, new File(installPath), heapInM, debugPort);
     this.installedServers.add(installation);
   }
   


### PR DESCRIPTION
-this allows the server Xms and Xmx to be specified as one of the harness options
-currently, this value is defaulted to 128 but it is now exposed at the right level to allow it to be modified, in the future (potentially on a per-test, or environmental level)