### PR TITLE
Fix #80: Error handler class can now be passed to TestClientStub

### DIFF
--- a/galvan-support/src/main/java/org/terracotta/testing/api/IClientErrorHandler.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/api/IClientErrorHandler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Terracotta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.testing.api;
+
+import org.terracotta.passthrough.IClientTestEnvironment;
+
+
+/**
+ * The interface implemented by classes which wish to be used as the client-side error handler by TestClientStub.
+ */
+public interface IClientErrorHandler {
+  /**
+   * Called by the TestClientStub exception handler in the case of a fatal error.  Typically, this is used to collect
+   *  diagnostic data to help determine why the test failed.
+   * 
+   * @param environment The environment of the test run in this client
+   * @param error The unhandled error
+   */
+  public void handleError(IClientTestEnvironment environment, Throwable error);
+}

--- a/galvan-support/src/main/java/org/terracotta/testing/master/BasicClientArgumentBuilder.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/master/BasicClientArgumentBuilder.java
@@ -26,10 +26,12 @@ import org.terracotta.testing.client.TestClientStub;
  */
 public class BasicClientArgumentBuilder implements IClientArgumentBuilder {
   private final String testClassName;
+  private final String errorClassName;
 
 
-  public BasicClientArgumentBuilder(String testClassName) {
+  public BasicClientArgumentBuilder(String testClassName, String errorClassName) {
     this.testClassName = testClassName;
+    this.errorClassName = errorClassName;
   }
 
   @Override
@@ -65,6 +67,10 @@ public class BasicClientArgumentBuilder implements IClientArgumentBuilder {
     args.add(Integer.toString(totalClientCount));
     args.add("--thisClientIndex");
     args.add(Integer.toString(thisClientIndex));
+    if (null != this.errorClassName) {
+      args.add("--errorClass");
+      args.add(this.errorClassName);
+    }
     return args;
   }
 }

--- a/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
@@ -59,7 +59,7 @@ public class BasicHarnessEntry extends AbstractHarnessEntry<BasicTestClusterConf
     clientsConfiguration.testParentDirectory = harnessOptions.configTestDirectory;
     clientsConfiguration.clientClassPath = harnessOptions.clientClassPath;
     clientsConfiguration.clientsToCreate = harnessOptions.clientsToCreate;
-    clientsConfiguration.clientArgumentBuilder = new BasicClientArgumentBuilder(harnessOptions.testClassName);
+    clientsConfiguration.clientArgumentBuilder = new BasicClientArgumentBuilder(harnessOptions.testClassName, harnessOptions.errorClassName);
     clientsConfiguration.connectUri = connectUri;
     clientsConfiguration.setupClientDebugPort = debugOptions.setupClientDebugPort;
     clientsConfiguration.destroyClientDebugPort = debugOptions.destroyClientDebugPort;

--- a/galvan-support/src/test/java/org/terracotta/testing/support/MultiProcessGalvanTest.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/support/MultiProcessGalvanTest.java
@@ -52,6 +52,12 @@ public abstract class MultiProcessGalvanTest extends BasicHarnessTest implements
   }
 
   @Override
+  public String getClientErrorHandlerClassName() {
+    // This implementation doesn't have a client error handler.
+    return null;
+  }
+
+  @Override
   public boolean isRestartable() {
     return false;
   }

--- a/galvan/src/main/java/org/terracotta/testing/api/ITestMaster.java
+++ b/galvan/src/main/java/org/terracotta/testing/api/ITestMaster.java
@@ -32,6 +32,13 @@ public interface ITestMaster<C extends ITestClusterConfiguration> {
 
   public String getTestClassName();
 
+  /**
+   * The error class must implement IClientErrorHandler but is optional so null can be returned here.
+   * 
+   * @return The name of the IClientErrorHandler implementation to use in the client.  Null if none desired.
+   */
+  public String getClientErrorHandlerClassName();
+
   public int getClientsToStart();
 
   public boolean isRestartable();

--- a/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
@@ -90,6 +90,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
       harnessOptions.clientClassPath = environmentOptions.clientClassPath;
       harnessOptions.clientsToCreate = clientsToCreate;
       harnessOptions.testClassName = testClassName;
+      harnessOptions.errorClassName = master.getClientErrorHandlerClassName();
       harnessOptions.isRestartable = isRestartable;
       harnessOptions.extraJarPaths = extraJarPaths;
       harnessOptions.namespaceFragment = namespaceFragment;
@@ -136,6 +137,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     public String clientClassPath;
     public int clientsToCreate;
     public String testClassName;
+    public String errorClassName;
     public int serverHeapInM;
     public boolean isRestartable;
     public List<String> extraJarPaths;


### PR DESCRIPTION
-this allows a call-out to an external error handler when a test fails on the client side
-this class name comes from the ITestMaster, much like the test class name, itself