### PR TITLE
Crash the client if it observes a test failure before the harness does

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/common/IPCMessageConstants.java
+++ b/galvan/src/main/java/org/terracotta/testing/common/IPCMessageConstants.java
@@ -62,4 +62,15 @@ public class IPCMessageConstants {
   public static final String CLIENT_SHUT_DOWN = "CLIENT_SHUT_DOWN";
   public static final String CLIENT_SHUT_DOWN_SYN = synFrom(CLIENT_SHUT_DOWN);
   public static final String CLIENT_SHUT_DOWN_ACK = ackFrom(CLIENT_SHUT_DOWN);
+
+  /**
+   * This is a special case in that it is not a response from a specific client-originating message.
+   * Instead, this message can be passed back to the client, in the place of any other *_ACK in the case where a fatal
+   *  error was realized by the harness while processing the corresponding *_SYN message.
+   * NOTE:  It is unlikely that the *_SYN _caused_ the error.  Typically, the error is observed here simply because it is
+   *  the first time this client has contacted the harness since the actual problem occurred.  This also means that the
+   *  harness is about to realize the problem, itself, and forcefully terminate the client process.  The cleanest way to
+   *  handle this is for the client to terminate itself so that the harness can more quickly come down gracefully.
+   */
+  public static final String FATAL_CLUSTER_ACK = "FATAL_CLUSTER_ACK";
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/ClientEventManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ClientEventManager.java
@@ -37,104 +37,59 @@ public class ClientEventManager {
     Map<String, String> eventMap = new HashMap<String, String>();
     
     // We might want to register one handler for all events, instead of handling the cases this way.
-    String syncEventName = "Client Sync";
-    eventMap.put(IPCMessageConstants.SYNC_SYN, syncEventName);
-    subBus.on(syncEventName, new EventListener() {
+    installEventHandler(subBus, eventMap, control, IPCMessageConstants.SYNC, new ControlCaller() {
       @Override
-      public void onEvent(Event e) throws Throwable {
+      public void runWithControl(IMultiProcessControl control) throws Throwable {
         control.synchronizeClient();
-        // We also want to send the ACK to the client.
-        processStdin.println(IPCMessageConstants.SYNC_ACK);
-        processStdin.flush();
-      }});
+      }}, processStdin);
     
-    String terminateActiveEventName = "Terminate active";
-    eventMap.put(IPCMessageConstants.TERMINATE_ACTIVE_SYN, terminateActiveEventName);
-    subBus.on(terminateActiveEventName, new EventListener() {
+    installEventHandler(subBus, eventMap, control, IPCMessageConstants.TERMINATE_ACTIVE, new ControlCaller() {
       @Override
-      public void onEvent(Event e) throws Throwable {
+      public void runWithControl(IMultiProcessControl control) throws Throwable {
         control.terminateActive();
-        // We also want to send the ACK to the client.
-        processStdin.println(IPCMessageConstants.TERMINATE_ACTIVE_ACK);
-        processStdin.flush();
-      }});
+      }}, processStdin);
     
-    String terminateOnePassiveEventName = "Terminate one passive";
-    eventMap.put(IPCMessageConstants.TERMINATE_ONE_PASSIVE_SYN, terminateOnePassiveEventName);
-    subBus.on(terminateOnePassiveEventName, new EventListener() {
+    installEventHandler(subBus, eventMap, control, IPCMessageConstants.TERMINATE_ONE_PASSIVE, new ControlCaller() {
       @Override
-      public void onEvent(Event e) throws Throwable {
+      public void runWithControl(IMultiProcessControl control) throws Throwable {
         control.terminateOnePassive();
-        // We also want to send the ACK to the client.
-        processStdin.println(IPCMessageConstants.TERMINATE_ONE_PASSIVE_ACK);
-        processStdin.flush();
-      }});
+      }}, processStdin);
     
-    String startOneServerEventName = "Start one server";
-    eventMap.put(IPCMessageConstants.START_ONE_SERVER_SYN, startOneServerEventName);
-    subBus.on(startOneServerEventName, new EventListener() {
+    installEventHandler(subBus, eventMap, control, IPCMessageConstants.START_ONE_SERVER, new ControlCaller() {
       @Override
-      public void onEvent(Event e) throws Throwable {
+      public void runWithControl(IMultiProcessControl control) throws Throwable {
         control.startOneServer();
-        // We also want to send the ACK to the client.
-        processStdin.println(IPCMessageConstants.START_ONE_SERVER_ACK);
-        processStdin.flush();
-      }});
+      }}, processStdin);
     
-    String startAllServersEventName = "Start all servers";
-    eventMap.put(IPCMessageConstants.START_ALL_SERVERS_SYN, startAllServersEventName);
-    subBus.on(startAllServersEventName, new EventListener() {
+    installEventHandler(subBus, eventMap, control, IPCMessageConstants.START_ALL_SERVERS, new ControlCaller() {
       @Override
-      public void onEvent(Event e) throws Throwable {
+      public void runWithControl(IMultiProcessControl control) throws Throwable {
         control.startAllServers();
-        // We also want to send the ACK to the client.
-        processStdin.println(IPCMessageConstants.START_ALL_SERVERS_ACK);
-        processStdin.flush();
-      }});
+      }}, processStdin);
     
-    String shutDownStripeEventName = "Shut down stripe";
-    eventMap.put(IPCMessageConstants.SHUT_DOWN_STRIPE_SYN, shutDownStripeEventName);
-    subBus.on(shutDownStripeEventName, new EventListener() {
+    installEventHandler(subBus, eventMap, control, IPCMessageConstants.SHUT_DOWN_STRIPE, new ControlCaller() {
       @Override
-      public void onEvent(Event e) throws Throwable {
+      public void runWithControl(IMultiProcessControl control) throws Throwable {
         control.terminateAllServers();
-        // We also want to send the ACK to the client.
-        processStdin.println(IPCMessageConstants.SHUT_DOWN_STRIPE_ACK);
-        processStdin.flush();
-      }});
+      }}, processStdin);
     
-    String waitForActiveEventName = "Wait for active";
-    eventMap.put(IPCMessageConstants.WAIT_FOR_ACTIVE_SYN, waitForActiveEventName);
-    subBus.on(waitForActiveEventName, new EventListener() {
+    installEventHandler(subBus, eventMap, control, IPCMessageConstants.WAIT_FOR_ACTIVE, new ControlCaller() {
       @Override
-      public void onEvent(Event e) throws Throwable {
+      public void runWithControl(IMultiProcessControl control) throws Throwable {
         control.waitForActive();
-        // We also want to send the ACK to the client.
-        processStdin.println(IPCMessageConstants.WAIT_FOR_ACTIVE_ACK);
-        processStdin.flush();
-      }});
+      }}, processStdin);
     
-    String waitForPassiveEventName = "Wait for passive";
-    eventMap.put(IPCMessageConstants.WAIT_FOR_PASSIVE_SYN, waitForPassiveEventName);
-    subBus.on(waitForPassiveEventName, new EventListener() {
+    installEventHandler(subBus, eventMap, control, IPCMessageConstants.WAIT_FOR_PASSIVE, new ControlCaller() {
       @Override
-      public void onEvent(Event e) throws Throwable {
+      public void runWithControl(IMultiProcessControl control) throws Throwable {
         control.waitForRunningPassivesInStandby();
-        // We also want to send the ACK to the client.
-        processStdin.println(IPCMessageConstants.WAIT_FOR_PASSIVE_ACK);
-        processStdin.flush();
-      }});
+      }}, processStdin);
     
-    String shutDownClientEventName = "Client shut down";
-    eventMap.put(IPCMessageConstants.CLIENT_SHUT_DOWN_SYN, shutDownClientEventName);
-    subBus.on(shutDownClientEventName, new EventListener() {
+    installEventHandler(subBus, eventMap, control, IPCMessageConstants.CLIENT_SHUT_DOWN, new ControlCaller() {
       @Override
-      public void onEvent(Event e) throws Throwable {
-        // We want to ACK to the client so they know that they can shut down.
-        processStdin.println(IPCMessageConstants.CLIENT_SHUT_DOWN_ACK);
-        // Then we need to close the stream in order to avoid broken pipe exceptions.
-        processStdin.close();
-      }});
+      public void runWithControl(IMultiProcessControl control) throws Throwable {
+        // We do nothing - just acknowledge this.
+      }}, processStdin);
     
     this.eventingStream = new SimpleEventingStream(subBus, eventMap, dataSink);
   }
@@ -144,5 +99,24 @@ public class ClientEventManager {
    */
   public OutputStream getEventingStream() {
     return this.eventingStream;
+  }
+
+
+  private void installEventHandler(EventBus subBus, Map<String, String> eventMap, final IMultiProcessControl control, String eventNameBase, ControlCaller call, final PrintStream processStdin) {
+    eventMap.put(IPCMessageConstants.synFrom(eventNameBase), eventNameBase);
+    subBus.on(eventNameBase, new EventListener() {
+      @Override
+      public void onEvent(Event e) throws Throwable {
+        String responseToSend = IPCMessageConstants.ackFrom(eventNameBase);
+        call.runWithControl(control);
+        
+        // We also want to send the ACK to the client.
+        processStdin.println(responseToSend);
+        processStdin.flush();
+      }});
+  }
+
+  private static interface ControlCaller {
+    void runWithControl(IMultiProcessControl control) throws Throwable;
   }
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/ClientEventManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ClientEventManager.java
@@ -106,10 +106,14 @@ public class ClientEventManager {
     eventMap.put(IPCMessageConstants.synFrom(eventNameBase), eventNameBase);
     subBus.on(eventNameBase, new EventListener() {
       @Override
-      public void onEvent(Event e) throws Throwable {
+      public void onEvent(Event e) {
         String responseToSend = IPCMessageConstants.ackFrom(eventNameBase);
-        call.runWithControl(control);
-        
+        try {
+          call.runWithControl(control);
+        } catch (Throwable t) {
+          System.err.println("WARNING:  Client being sent FATAL ack (while processing " + eventNameBase + ") due to internal error: " + t);
+          responseToSend = IPCMessageConstants.FATAL_CLUSTER_ACK;
+        }
         // We also want to send the ACK to the client.
         processStdin.println(responseToSend);
         processStdin.flush();


### PR DESCRIPTION
This alleviates the issue of the harness incorrectly detecting a failure in the client IPC path as a fatal internal error.  The exception is actually a failure in the test which the client observed before the harness (hence why this particular bug is so intermittent).