### PR TITLE
[WAIT FOR MERGE] Fix #84: No longer manage an implicit Connection in a test

### DIFF
--- a/galvan-support/pom.xml
+++ b/galvan-support/pom.xml
@@ -32,7 +32,7 @@ limitations under the License.
     <kitUnzipLocation>${project.build.directory}/test-kit</kitUnzipLocation>
 
     <!-- External dependency versions for this module -->
-    <tc-passthrough-testing.version>1.0.4.beta</tc-passthrough-testing.version>
+    <tc-passthrough-testing.version>1.0.4.beta2</tc-passthrough-testing.version>
     <terracotta-core.version>5.0.4-beta</terracotta-core.version>
   </properties>
 

--- a/galvan-support/src/main/java/org/terracotta/testing/client/TestClientStub.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/client/TestClientStub.java
@@ -16,12 +16,7 @@
 package org.terracotta.testing.client;
 
 import java.lang.Thread.UncaughtExceptionHandler;
-import java.net.URI;
-import java.util.Properties;
 
-import org.terracotta.connection.Connection;
-import org.terracotta.connection.ConnectionException;
-import org.terracotta.connection.ConnectionFactory;
 import org.terracotta.passthrough.IClientTestEnvironment;
 import org.terracotta.passthrough.ICommonTest;
 import org.terracotta.passthrough.SimpleClientTestEnvironment;
@@ -84,25 +79,16 @@ public class TestClientStub {
     ICommonTest test = interfaceClass.cast(instance);
     
     IPCClusterControl clusterControl = new IPCClusterControl(manager);
-    // Create the initial connection we want to use.
-    Connection connection = null;
-    try {
-      connection = ConnectionFactory.connect(URI.create(connectUri), new Properties());
-    } catch (ConnectionException e) {
-      // We may want to change this API, in the future, but it is only for tests so it is uncertain if we would do anything other than fail, in this scenario.
-      throw new RuntimeException("Unexpected exception when creating connection to cluster", e);
-    }
     
     if (isSetup) {
-      test.runSetup(TestClientStub.testEnvironment, clusterControl, connection);
+      test.runSetup(TestClientStub.testEnvironment, clusterControl);
     }
     if (isTest) {
-      test.runTest(TestClientStub.testEnvironment, clusterControl, connection);
+      test.runTest(TestClientStub.testEnvironment, clusterControl);
     }
     if (isDestroy) {
-      test.runDestroy(TestClientStub.testEnvironment, clusterControl, connection);
+      test.runDestroy(TestClientStub.testEnvironment, clusterControl);
     }
-    connection.close();
     manager.sendShutDownAndWait();
     
     // Note that this explicit exit seems to be required when attached to an active-active cluster.

--- a/galvan-support/src/test/java/org/terracotta/testing/support/CorruptServerConfigIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/support/CorruptServerConfigIT.java
@@ -5,7 +5,6 @@
  */
 package org.terracotta.testing.support;
 
-import org.terracotta.connection.Connection;
 import org.terracotta.passthrough.IClientTestEnvironment;
 import org.terracotta.passthrough.IClusterControl;
 
@@ -35,7 +34,7 @@ public class CorruptServerConfigIT extends MultiProcessGalvanTest {
   }
 
   @Override
-  public void runTest(IClientTestEnvironment env, IClusterControl control, Connection connection) throws Throwable {
+  public void runTest(IClientTestEnvironment env, IClusterControl control) throws Throwable {
     int clientIndex = env.getThisClientIndex();
     System.out.println("Running in client: " + clientIndex);
   }

--- a/galvan-support/src/test/java/org/terracotta/testing/support/CrashAndHangClientsIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/support/CrashAndHangClientsIT.java
@@ -6,7 +6,6 @@
 package org.terracotta.testing.support;
 
 import org.junit.Assert;
-import org.terracotta.connection.Connection;
 import org.terracotta.passthrough.IClientTestEnvironment;
 import org.terracotta.passthrough.IClusterControl;
 
@@ -34,7 +33,7 @@ public class CrashAndHangClientsIT extends MultiProcessGalvanTest {
   }
 
   @Override
-  public void runTest(IClientTestEnvironment env, IClusterControl control, Connection connection) throws Throwable {
+  public void runTest(IClientTestEnvironment env, IClusterControl control) throws Throwable {
     int clientIndex = env.getThisClientIndex();
     System.out.println("Running client: " + clientIndex);
     if (0 == clientIndex) {

--- a/galvan-support/src/test/java/org/terracotta/testing/support/MultiProcessGalvanTest.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/support/MultiProcessGalvanTest.java
@@ -8,7 +8,6 @@ package org.terracotta.testing.support;
 import java.util.Collections;
 import java.util.List;
 
-import org.terracotta.connection.Connection;
 import org.terracotta.passthrough.IClientTestEnvironment;
 import org.terracotta.passthrough.IClusterControl;
 import org.terracotta.passthrough.ICommonTest;
@@ -74,12 +73,12 @@ public abstract class MultiProcessGalvanTest extends BasicHarnessTest implements
   }
 
   @Override
-  public void runSetup(IClientTestEnvironment env, IClusterControl control, Connection connection) {
+  public void runSetup(IClientTestEnvironment env, IClusterControl control) {
     // These tests generally don't care about this.
   }
 
   @Override
-  public void runDestroy(IClientTestEnvironment env, IClusterControl control, Connection connection) {
+  public void runDestroy(IClientTestEnvironment env, IClusterControl control) {
     // These tests generally don't care about this.
   }
 }

--- a/galvan-support/src/test/java/org/terracotta/testing/support/SimpleClientStartUpIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/support/SimpleClientStartUpIT.java
@@ -6,7 +6,6 @@
 package org.terracotta.testing.support;
 
 import org.junit.Assert;
-import org.terracotta.connection.Connection;
 import org.terracotta.passthrough.IClientTestEnvironment;
 import org.terracotta.passthrough.IClusterControl;
 
@@ -23,21 +22,21 @@ public class SimpleClientStartUpIT extends MultiProcessGalvanTest {
   }
 
   @Override
-  public void runSetup(IClientTestEnvironment env, IClusterControl control, Connection connection) {
+  public void runSetup(IClientTestEnvironment env, IClusterControl control) {
     // Just verify that the client counts are expected.
     Assert.assertTrue(CLIENT_COUNT == env.getTotalClientCount());
     Assert.assertTrue(0 == env.getThisClientIndex());
   }
 
   @Override
-  public void runDestroy(IClientTestEnvironment env, IClusterControl control, Connection connection) {
+  public void runDestroy(IClientTestEnvironment env, IClusterControl control) {
     // These tests generally don't care about this.
     Assert.assertTrue(CLIENT_COUNT == env.getTotalClientCount());
     Assert.assertTrue(0 == env.getThisClientIndex());
   }
 
   @Override
-  public void runTest(IClientTestEnvironment env, IClusterControl control, Connection connection) throws Throwable {
+  public void runTest(IClientTestEnvironment env, IClusterControl control) throws Throwable {
     int clientIndex = env.getThisClientIndex();
     Assert.assertTrue(clientIndex >= 0);
     Assert.assertTrue(clientIndex < CLIENT_COUNT);


### PR DESCRIPTION
-this adapts to the API change for ICommonTest to remove the Connection argument
-this also means that the problems experienced as a result of these implicit Connections (timeouts or unuexpected errors as a result of the test, itself) are no longer possible (as each Connection is now the direct responsibilty of the test, not the harness or entry-point)

NOTE:  This depends on a release of tc-passthrough-testing to accept the API change