### PR TITLE
Updated deps and added support for new IClientTestEnvironment methods

### DIFF
--- a/galvan-support/pom.xml
+++ b/galvan-support/pom.xml
@@ -32,8 +32,8 @@ limitations under the License.
     <kitUnzipLocation>${project.build.directory}/test-kit</kitUnzipLocation>
 
     <!-- External dependency versions for this module -->
-    <tc-passthrough-testing.version>1.0.6.beta</tc-passthrough-testing.version>
-    <terracotta-core.version>5.0.6-beta</terracotta-core.version>
+    <tc-passthrough-testing.version>1.0.6.beta2</tc-passthrough-testing.version>
+    <terracotta-core.version>5.0.6-beta2</terracotta-core.version>
   </properties>
 
   <dependencies>

--- a/galvan-support/src/main/java/org/terracotta/testing/client/TestClientStub.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/client/TestClientStub.java
@@ -43,6 +43,8 @@ public class TestClientStub {
    * --connectUri:  <the cluster URI used in the test>
    * --totalClientCount:  <number of clients running the test>
    * --thisClientIndex:  <the 0-indexed number of this client instance>
+   * --numberOfStripes:  <number of stripes in this environment>
+   * --numberOfServersPerStripe:  <number of servers in each stripe in this environment>
    * [--errorClass]:  An optional argument, specifies the name of the failure handler class
    */
   public static void main(String[] args) throws Throwable {
@@ -56,6 +58,8 @@ public class TestClientStub {
     String clusterInfo = readArgString(args, "--clusterInfo");
     int totalClientCount = readArgInt(args, "--totalClientCount");
     int thisClientIndex = readArgInt(args, "--thisClientIndex");
+    int numberOfStripes = readArgInt(args, "--numberOfStripes");
+    int numberOfServersPerStripe = readArgInt(args, "--numberOfServersPerStripe");
     String errorClassName = readArgStringOrNull(args, "--errorClass");
     
     // First thing, we want to see if we were given an error class, since it will handle any errors we encounter through
@@ -69,7 +73,7 @@ public class TestClientStub {
     }
     
     // Get the environment (we will pass this in all cases but it is only useful for TEST modes).
-    TestClientStub.testEnvironment = new SimpleClientTestEnvironment(connectUri, totalClientCount, thisClientIndex, getClusterInfo(clusterInfo));
+    TestClientStub.testEnvironment = new SimpleClientTestEnvironment(connectUri, totalClientCount, thisClientIndex, getClusterInfo(clusterInfo), numberOfStripes, numberOfServersPerStripe);
     
     boolean isSetup = task.equals("SETUP");
     boolean isTest = task.equals("TEST");

--- a/galvan-support/src/main/java/org/terracotta/testing/master/BasicClientArgumentBuilder.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/master/BasicClientArgumentBuilder.java
@@ -40,22 +40,22 @@ public class BasicClientArgumentBuilder implements IClientArgumentBuilder {
   }
 
   @Override
-  public List<String> getArgumentsForSetupRun(String connectUri, ClusterInfo clusterInfo, int totalClientCount) {
-    return buildList("SETUP", connectUri, clusterInfo, totalClientCount, 0);
+  public List<String> getArgumentsForSetupRun(String connectUri, ClusterInfo clusterInfo, int numberOfStripes, int numberOfServersPerStripe, int totalClientCount) {
+    return buildList("SETUP", connectUri, clusterInfo, numberOfStripes, numberOfServersPerStripe, totalClientCount, 0);
   }
 
   @Override
-  public List<String> getArgumentsForTestRun(String connectUri, ClusterInfo clusterInfo, int totalClientCount, int thisClientIndex) {
-    return buildList("TEST", connectUri, clusterInfo, totalClientCount, thisClientIndex);
+  public List<String> getArgumentsForTestRun(String connectUri, ClusterInfo clusterInfo, int numberOfStripes, int numberOfServersPerStripe, int totalClientCount, int thisClientIndex) {
+    return buildList("TEST", connectUri, clusterInfo, numberOfStripes, numberOfServersPerStripe, totalClientCount, thisClientIndex);
   }
 
   @Override
-  public List<String> getArgumentsForDestroyRun(String connectUri, ClusterInfo clusterInfo, int totalClientCount) {
-    return buildList("DESTROY", connectUri, clusterInfo, totalClientCount, 0);
+  public List<String> getArgumentsForDestroyRun(String connectUri, ClusterInfo clusterInfo, int numberOfStripes, int numberOfServersPerStripe, int totalClientCount) {
+    return buildList("DESTROY", connectUri, clusterInfo, numberOfStripes, numberOfServersPerStripe, totalClientCount, 0);
   }
 
 
-  private List<String> buildList(String task, String connectUri, ClusterInfo clusterInfo, int totalClientCount, int thisClientIndex) {
+  private List<String> buildList(String task, String connectUri, ClusterInfo clusterInfo, int numberOfStripes, int numberOfServersPerStripe, int totalClientCount, int thisClientIndex) {
     List<String> args = new Vector<String>();
     args.add("--task");
     args.add(task);
@@ -63,12 +63,18 @@ public class BasicClientArgumentBuilder implements IClientArgumentBuilder {
     args.add(this.testClassName);
     args.add("--connectUri");
     args.add(connectUri);
+    args.add("--clusterInfo");
+    args.add(clusterInfo.encode());
+    args.add("--numberOfStripes");
+    args.add(Integer.toString(numberOfStripes));
+    args.add("--numberOfServersPerStripe");
+    args.add(Integer.toString(numberOfServersPerStripe));
+    
     args.add("--totalClientCount");
     args.add(Integer.toString(totalClientCount));
     args.add("--thisClientIndex");
     args.add(Integer.toString(thisClientIndex));
-    args.add("--clusterInfo");
-    args.add(clusterInfo.encode());
+    
     if (null != this.errorClassName) {
       args.add("--errorClass");
       args.add(this.errorClassName);

--- a/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
@@ -63,6 +63,9 @@ public class BasicHarnessEntry extends AbstractHarnessEntry<BasicTestClusterConf
     clientsConfiguration.clientArgumentBuilder = new BasicClientArgumentBuilder(harnessOptions.testClassName, harnessOptions.errorClassName);
     clientsConfiguration.connectUri = connectUri;
     clientsConfiguration.clusterInfo = clusterInfo;
+    // The basic harness can only run single-stripe tests.
+    clientsConfiguration.numberOfStripes = 1;
+    clientsConfiguration.numberOfServersPerStripe = runConfiguration.serversInStripe;
     clientsConfiguration.setupClientDebugPort = debugOptions.setupClientDebugPort;
     clientsConfiguration.destroyClientDebugPort = debugOptions.destroyClientDebugPort;
     clientsConfiguration.testClientDebugPortStart = debugOptions.testClientDebugPortStart;

--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -37,7 +37,7 @@ public class CommonIdioms {
    * Note that the clients will be run in another thread, logging to the given logger and returning their state in stateManager.
    */
   public static void installAndRunClients(IGalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager verboseManager, ClientsConfiguration clientsConfiguration, IMultiProcessControl processControl) throws IOException {
-    ClientSubProcessManager manager = new ClientSubProcessManager(interlock, stateManager, verboseManager, processControl, clientsConfiguration.testParentDirectory, clientsConfiguration.clientClassPath, clientsConfiguration.setupClientDebugPort, clientsConfiguration.destroyClientDebugPort, clientsConfiguration.testClientDebugPortStart, clientsConfiguration.clientsToCreate, clientsConfiguration.clientArgumentBuilder, clientsConfiguration.connectUri, clientsConfiguration.clusterInfo);
+    ClientSubProcessManager manager = new ClientSubProcessManager(interlock, stateManager, verboseManager, processControl, clientsConfiguration.testParentDirectory, clientsConfiguration.clientClassPath, clientsConfiguration.setupClientDebugPort, clientsConfiguration.destroyClientDebugPort, clientsConfiguration.testClientDebugPortStart, clientsConfiguration.clientsToCreate, clientsConfiguration.clientArgumentBuilder, clientsConfiguration.connectUri, clientsConfiguration.clusterInfo, clientsConfiguration.numberOfStripes, clientsConfiguration.numberOfServersPerStripe);
     manager.start();
   }
 
@@ -77,6 +77,8 @@ public class CommonIdioms {
   /**
    * This class is essentially a struct containing the data which describes how the client for a test are to be
    * configured and how they should be run.
+   * Additionally, it also provides much of the environment description and other meta-data which tests can use
+   * to calibrate themselves.
    * It exists to give context to the parameters in CommonIdioms.
    */
   public static class ClientsConfiguration {
@@ -85,6 +87,8 @@ public class CommonIdioms {
     public int clientsToCreate;
     public IClientArgumentBuilder clientArgumentBuilder;
     public String connectUri;
+    public int numberOfStripes;
+    public int numberOfServersPerStripe;
     
     // Debug options specific to clients.
     public int setupClientDebugPort;

--- a/galvan/src/main/java/org/terracotta/testing/master/IClientArgumentBuilder.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/IClientArgumentBuilder.java
@@ -32,27 +32,33 @@ public interface IClientArgumentBuilder {
    * Creates the argument list for a "setup" client run.
    * 
    * @param connectUri The URI of the test stripe
+   * @param numberOfStripes The number of stripes in the test environment
+   * @param numberOfServersPerStripe The number of servers in each stripe in the test environment
    * @param totalClientCount The total number of test clients which will run the test, concurrently
    * @return The list of arguments to pass to the client main
    */
-  public List<String> getArgumentsForSetupRun(String connectUri, ClusterInfo clusterInfo, int totalClientCount);
+  public List<String> getArgumentsForSetupRun(String connectUri, ClusterInfo clusterInfo, int numberOfStripes, int numberOfServersPerStripe, int totalClientCount);
 
   /**
    * Creates the argument list for a regular "test" client run.
    * 
    * @param connectUri The URI of the test stripe
+   * @param numberOfStripes The number of stripes in the test environment
+   * @param numberOfServersPerStripe The number of servers in each stripe in the test environment
    * @param totalClientCount The total number of test clients being run, concurrently
    * @param thisClientIndex The index number of this client, within the set of concurrent test clients
    * @return The list of arguments to pass to the client main
    */
-  public List<String> getArgumentsForTestRun(String connectUri, ClusterInfo clusterInfo, int totalClientCount, int thisClientIndex);
+  public List<String> getArgumentsForTestRun(String connectUri, ClusterInfo clusterInfo, int numberOfStripes, int numberOfServersPerStripe, int totalClientCount, int thisClientIndex);
 
   /**
    * Creates the argument list for a "destroy" client run.
    * 
    * @param connectUri The URI of the test stripe
+   * @param numberOfStripes The number of stripes in the test environment
+   * @param numberOfServersPerStripe The number of servers in each stripe in the test environment
    * @param totalClientCount The total number of test clients which will run the test, concurrently
    * @return The list of arguments to pass to the client main
    */
-  public List<String> getArgumentsForDestroyRun(String connectUri, ClusterInfo clusterInfo, int totalClientCount);
+  public List<String> getArgumentsForDestroyRun(String connectUri, ClusterInfo clusterInfo, int numberOfStripes, int numberOfServersPerStripe, int totalClientCount);
 }


### PR DESCRIPTION
-this is primarily plumbing numberOfStripes and numberOfServersPerStripe down from the configuration into the TestClientStub so that it can be populated for the tests
-additionally, added some checks that the arguments are consistent, in ClientSubProcessManager
-note that the internal harness can only support single-stripe environments