### PR TITLE
Fix #103: Calculate the required number of ports, up front

### DIFF
--- a/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/master/BasicHarnessEntry.java
@@ -29,12 +29,15 @@ public class BasicHarnessEntry extends AbstractHarnessEntry<BasicTestClusterConf
     int serversToCreate = runConfiguration.serversInStripe;
     Assert.assertTrue(serversToCreate > 0);
     
+    // Calculate the size of the port range we need:  each server needs 2 ports.
+    int portsRequired = serversToCreate * 2;
+    
     CommonIdioms.StripeConfiguration stripeConfiguration = new CommonIdioms.StripeConfiguration();
     stripeConfiguration.kitOriginPath = harnessOptions.kitOriginPath;
     stripeConfiguration.testParentDirectory = harnessOptions.configTestDirectory;
     stripeConfiguration.serversToCreate = serversToCreate;
     stripeConfiguration.serverHeapInM = harnessOptions.serverHeapInM;
-    stripeConfiguration.serverStartPort = chooseRandomPort();
+    stripeConfiguration.serverStartPort = chooseRandomPortRange(portsRequired);
     stripeConfiguration.serverDebugPortStart = debugOptions.serverDebugPortStart;
     stripeConfiguration.serverStartNumber = 0;
     stripeConfiguration.isRestartable = harnessOptions.isRestartable;

--- a/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
@@ -44,11 +44,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
       throw e;
     }
   }
-  
-  public int chooseRandomPort() {
-    return chooser.chooseRandomPort();
-  }
-  
+
   public int chooseRandomPortRange(int number) {
     return chooser.chooseRandomPorts(number);
   }


### PR DESCRIPTION
-this fixes an issue where the PortChooser was only asked to find one port but then we used that as the base of the range we actually needed (which is less likely to work)