### PR TITLE
Issue 111

### DIFF
--- a/galvan-support/src/test/java/org/terracotta/testing/rules/BasicExternalClusterImmediateControlIT.java
+++ b/galvan-support/src/test/java/org/terracotta/testing/rules/BasicExternalClusterImmediateControlIT.java
@@ -1,0 +1,94 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.terracotta.testing.rules;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.terracotta.connection.ConnectionException;
+import org.terracotta.testing.common.Assert;
+
+
+/**
+ * A test that attempts to immediately control the cluster, via IClusterControl, behave correctly.
+ * This addresses the issue demonstrated in issue-111.
+ */
+public class BasicExternalClusterImmediateControlIT {
+  private static final int SERVER_COUNT = 2;
+
+  @Rule
+  public final Cluster cluster = new BasicExternalCluster(new File("target/cluster"), SERVER_COUNT);
+
+  @Test
+  public void waitForActive() throws IOException, ConnectionException {
+    try {
+      this.cluster.getClusterControl().waitForActive();
+    } catch (Exception e) {
+      Assert.unexpected(e);
+    }
+  }
+
+  @Test
+  public void waitForRunningPassivesInStandby() throws IOException, ConnectionException {
+    try {
+      this.cluster.getClusterControl().waitForRunningPassivesInStandby();
+    } catch (Exception e) {
+      Assert.unexpected(e);
+    }
+  }
+
+  @Test
+  public void startOneServer() throws IOException, ConnectionException {
+    boolean didFail = false;
+    try {
+      this.cluster.getClusterControl().startOneServer();
+      didFail = false;
+    } catch (IllegalStateException e) {
+      // This is expected - there are no terminated servers.
+      didFail = true;
+    } catch (Exception e) {
+      Assert.unexpected(e);
+    }
+    Assert.assertTrue(didFail);
+  }
+
+  @Test
+  public void startAllServers() throws IOException, ConnectionException {
+    try {
+      this.cluster.getClusterControl().startAllServers();
+    } catch (Exception e) {
+      Assert.unexpected(e);
+    }
+  }
+
+  @Test
+  public void terminateActive() throws IOException, ConnectionException {
+    try {
+      this.cluster.getClusterControl().terminateActive();
+    } catch (Exception e) {
+      Assert.unexpected(e);
+    }
+  }
+
+  @Test
+  public void terminateOnePassive() throws IOException, ConnectionException {
+    try {
+      this.cluster.getClusterControl().terminateOnePassive();
+    } catch (Exception e) {
+      Assert.unexpected(e);
+    }
+  }
+
+  @Test
+  public void terminateAllServers() throws IOException, ConnectionException {
+    try {
+      this.cluster.getClusterControl().terminateAllServers();
+    } catch (Exception e) {
+      Assert.unexpected(e);
+    }
+  }
+}

--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -27,7 +27,7 @@ import org.terracotta.testing.logging.VerboseManager;
  * It exists purely to avoid duplication.
  */
 public class CommonIdioms {
-  public static ReadyStripe setupConfigureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager verboseManager, StripeConfiguration stripeConfiguration) throws IOException {
+  public static ReadyStripe setupConfigureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager verboseManager, StripeConfiguration stripeConfiguration) throws IOException, GalvanFailureException {
     VerboseManager stripeVerboseManager = verboseManager.createComponentManager("[" + stripeConfiguration.stripeName + "]");
     // We want to create a sub-directory per-stripe.
     String stripeParentDirectory = FileHelpers.createTempEmptyDirectory(stripeConfiguration.testParentDirectory, stripeConfiguration.stripeName);

--- a/galvan/src/main/java/org/terracotta/testing/master/GalvanStateInterlock.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/GalvanStateInterlock.java
@@ -135,6 +135,17 @@ public class GalvanStateInterlock implements IGalvanStateInterlock {
   }
 
   @Override
+  public void waitForAllServerRunning() throws GalvanFailureException {
+    synchronized (this.sharedLockState) {
+      this.logger.output("> waitForAllServerRunning");
+      while (!this.sharedLockState.checkDidPass() && (!this.terminatedServers.isEmpty() || !this.zappedServers.isEmpty())) {
+        safeWait();
+      }
+      this.logger.output("< waitForAllServerRunning");
+    }
+  }
+
+  @Override
   public void waitForAllServerReady() throws GalvanFailureException {
     synchronized (this.sharedLockState) {
       this.logger.output("> waitForAllServerReady");

--- a/galvan/src/main/java/org/terracotta/testing/master/GalvanStateInterlock.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/GalvanStateInterlock.java
@@ -65,20 +65,23 @@ public class GalvanStateInterlock implements IGalvanStateInterlock {
   @Override
   public void registerNewServer(ServerProcess newServer) {
     synchronized (this.sharedLockState) {
+      this.logger.output("registerNewServer: " + newServer);
       // No new registration during shutdown.
       Assert.assertFalse(this.isShuttingDown);
-      this.logger.output("registerNewServer: " + newServer);
       Assert.assertFalse(this.terminatedServers.contains(newServer));
       this.terminatedServers.add(newServer);
     }
   }
 
   @Override
-  public void registerRunningClient(ClientRunner runningClient) {
+  public void registerRunningClient(ClientRunner runningClient) throws GalvanFailureException {
     synchronized (this.sharedLockState) {
-      // No new registration during shutdown.
-      Assert.assertFalse(this.isShuttingDown);
       this.logger.output("registerRunningClient: " + runningClient);
+      // No new registration during shutdown.
+      if (this.isShuttingDown) {
+        throw new GalvanFailureException("Failed to register new client when already shutting down");
+      }
+      Assert.assertFalse(this.isShuttingDown);
       Assert.assertFalse(this.runningClients.contains(runningClient));
       this.runningClients.add(runningClient);
     }

--- a/galvan/src/main/java/org/terracotta/testing/master/IGalvanStateInterlock.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/IGalvanStateInterlock.java
@@ -71,6 +71,13 @@ public interface IGalvanStateInterlock {
    */
   public void waitForServerTermination(ServerProcess terminatedServer) throws GalvanFailureException;
   /**
+   * Waits until all running servers, known to the interlock, have at least reported that they are running.
+   * This will block until there are no more terminated or zapped servers.
+   * 
+   * @throws GalvanFailureException The test failure description, if it already failed.
+   */
+  public void waitForAllServerRunning() throws GalvanFailureException;
+  /**
    * Waits until all running servers, known to the interlock, have entered a known (active or passive) state.
    * 
    * @throws GalvanFailureException The test failure description, if it already failed.

--- a/galvan/src/main/java/org/terracotta/testing/master/IGalvanStateInterlock.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/IGalvanStateInterlock.java
@@ -39,8 +39,9 @@ public interface IGalvanStateInterlock {
    *  running, as it will drop them when they terminate.
    * 
    * @param runningClient The running client to register.
+   * @throws GalvanFailureException The test failure description, if it already failed.
    */
-  public void registerRunningClient(ClientRunner runningClient);
+  public void registerRunningClient(ClientRunner runningClient) throws GalvanFailureException;
 
   // ----- WAITING-----
   /**

--- a/galvan/src/main/java/org/terracotta/testing/master/IMultiProcessControl.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/IMultiProcessControl.java
@@ -27,10 +27,22 @@ package org.terracotta.testing.master;
 public interface IMultiProcessControl {
   public void synchronizeClient() throws GalvanFailureException;
 
+  /**
+   * Terminates the active server, waiting for it to shut down.
+   * 
+   * @throws IllegalStateException There is no active server.
+   * @throws GalvanFailureException The test has failed.
+   */
   public void terminateActive() throws GalvanFailureException;
 
   public void terminateOnePassive() throws GalvanFailureException;
 
+  /**
+   * Starts one terminated server, waiting for it to start.
+   * 
+   * @throws IllegalStateException There are no terminated servers.
+   * @throws GalvanFailureException The test has failed.
+   */
   public void startOneServer() throws GalvanFailureException;
 
   public void startAllServers() throws GalvanFailureException;

--- a/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
@@ -26,7 +26,34 @@ import org.terracotta.testing.logging.VerboseManager;
  * A helper to install, configure, and start a single stripe, along with read-only data describing how to interact with it.
  */
 public class ReadyStripe {
-  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String testParentDirectory, int serversToCreate, int heapInM, int serverStartPort, int serverDebugPortStart, int serverStartNumber, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment) throws IOException {
+  /**
+   * Installs, configures, and starts the described stripe.
+   * When this call returns, all the servers in the stripe will be installed an running (at least in an "unknownRunning"
+   *  state within the given interlock.
+   * 
+   * @param interlock Coordinates the relationship between the test and its inferior processes.
+   * @param stateManager The object where test externals can wait for the result of a test.
+   * @param stripeVerboseManager Controls verbose output for the servers within the stripe.
+   * @param serverInstallDirectory The top-level directory under which all servers are installed.
+   * @param kitOriginDirectory The location where the clean kit is installed.
+   * @param serversToCreate The number of servers to install and start within the stripe.
+   * @param heapInM The heap size to specify to the server JVM (both -Xms and -Xmx).
+   * @param serverStartPort The port where servers will start being assigned.  Each server is assigned a port after the
+   *  last, starting at this number.
+   * @param serverDebugPortStart The port where servers will start looking for debug connections.  Each server is assigned a
+   *  port after the last, starting at this number.  0 means "no debug".
+   * @param serverStartNumber The server number to use.  This is so different stripes or configs don't collide with each
+   *  other on disk.
+   * @param isRestartable True if the servers in the stripe are restartable.
+   * @param extraJarPaths The full paths to additional jars which need to be installed in each server.
+   * @param namespaceFragment The namespace declaration string which must be injected into each config.
+   * @param serviceFragment The service definition string which must be injected into each config.
+   * @param entityFragment The static/built-in entity definition string which must be injected into each config.
+   * @return The objects required to interact with and control the stripe.
+   * @throws IOException Thrown in case something went wrong during server installation.
+   * @throws GalvanFailureException Thrown in case starting the servers in the stripe experienced a failure.
+   */
+  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String kitOriginDirectory, int serversToCreate, int heapInM, int serverStartPort, int serverDebugPortStart, int serverStartNumber, boolean isRestartable, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment) throws IOException, GalvanFailureException {
     ContextualLogger configLogger = stripeVerboseManager.createComponentManager("[ConfigBuilder]").createHarnessLogger();
     // Create the config builder.
     ConfigBuilder configBuilder = ConfigBuilder.buildStartPort(configLogger, serverStartPort);
@@ -38,7 +65,7 @@ public class ReadyStripe {
       configBuilder.setRestartable();
     }
     // Create the stripe installer.
-    StripeInstaller installer = new StripeInstaller(interlock, stateManager, stripeVerboseManager, testParentDirectory, serverInstallDirectory, extraJarPaths);
+    StripeInstaller installer = new StripeInstaller(interlock, stateManager, stripeVerboseManager, kitOriginDirectory, serverInstallDirectory, extraJarPaths);
     // Configure and install each server in the stripe.
     for (int i = 0; i < serversToCreate; ++i) {
       String serverName = "testServer" + (i + serverStartNumber);
@@ -57,6 +84,14 @@ public class ReadyStripe {
     ContextualLogger processControlLogger = stripeVerboseManager.createComponentManager("[ProcessControl]").createHarnessLogger();
     // Register the stripe into it and start up the server in the stripe.
     installer.startServers();
+    
+    // Before we return, we want to wait for all the servers in the stripe to come up.
+    interlock.waitForAllServerRunning();
+    
+    // Also, so we don't start the test in a racy state, wait for all the now-running servers to enter a meaningful state.
+    interlock.waitForAllServerReady();
+    
+    // We can now create the information required by the ReadyStripe and return control to the caller to run the test or install clients.
     SynchronousProcessControl processControl = new SynchronousProcessControl(interlock, processControlLogger);
     String connectUri = configBuilder.buildUri();
     ClusterInfo clusterInfo = configBuilder.getClusterInfo();

--- a/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
@@ -55,9 +55,9 @@ public class ReadyStripe {
     
     // Create the process control object.
     ContextualLogger processControlLogger = stripeVerboseManager.createComponentManager("[ProcessControl]").createHarnessLogger();
-    SynchronousProcessControl processControl = new SynchronousProcessControl(interlock, processControlLogger);
     // Register the stripe into it and start up the server in the stripe.
-    installer.startServers(processControl);
+    installer.startServers();
+    SynchronousProcessControl processControl = new SynchronousProcessControl(interlock, processControlLogger);
     String connectUri = configBuilder.buildUri();
     ClusterInfo clusterInfo = configBuilder.getClusterInfo();
     return new ReadyStripe(processControl, connectUri, clusterInfo, configText);

--- a/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
@@ -280,6 +280,7 @@ public class ServerProcess {
   private synchronized void didTerminateWithStatus(int exitStatus) {
     // See if we have a PID yet or if this was a failure, much earlier (hence, if we told the interlock that we are even running).
     GalvanFailureException failureException = null;
+    long originalPid = this.pid;
     if (this.pid > 0) {
       // Ok, tell the interlock.
       this.pid = 0;
@@ -289,7 +290,7 @@ public class ServerProcess {
       failureException = new GalvanFailureException("Server crashed before reporting PID: " + this);
     }
     if (!this.isCrashExpected && (null == failureException)) {
-      failureException = new GalvanFailureException("Unexpected server crash: " + this);
+      failureException = new GalvanFailureException("Unexpected server crash: " + this + " (PID " + originalPid + ") status: " + exitStatus);
     }
     
     if (null != failureException) {
@@ -323,7 +324,7 @@ public class ServerProcess {
     // Can't stop something unless we determined the PID.
     Assert.assertTrue(this.pid > 0);
     // Log the intent.
-    this.harnessLogger.output("Crashing server process: " + this);
+    this.harnessLogger.output("Crashing server process: " + this + " (PID " + this.pid + ")");
     // Mark this as expected.
     this.isCrashExpected = true;
     // Destroy the process.

--- a/galvan/src/main/java/org/terracotta/testing/master/StripeInstaller.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/StripeInstaller.java
@@ -73,7 +73,7 @@ public class StripeInstaller {
     }
   }
   
-  public void startServers(SynchronousProcessControl control) {
+  public void startServers() {
     Assert.assertFalse(this.isBuilt);
     for (ServerInstallation installation : this.installedServers) {
       // Note that starting the process will put it into the interlock and the server will notify it of state changes.

--- a/galvan/src/main/java/org/terracotta/testing/master/SynchronousProcessControl.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/SynchronousProcessControl.java
@@ -53,7 +53,9 @@ public class SynchronousProcessControl implements IMultiProcessControl {
     // Get the active and stop it.
     ServerProcess active = this.stateInterlock.getActiveServer();
     // We expect that the test knows there is an active (might change in the future).
-    Assert.assertNotNull(active);
+    if (null == active) {
+      throw new IllegalStateException("No server in active state");
+    }
     safeStop(active);
     
     // Wait until the server has gone down.
@@ -83,7 +85,9 @@ public class SynchronousProcessControl implements IMultiProcessControl {
   public synchronized void startOneServer() throws GalvanFailureException {
     this.logger.output(">>> startOneServer");
     ServerProcess server = this.stateInterlock.getOneTerminatedServer();
-    Assert.assertNotNull(server);
+    if (null == server) {
+      throw new IllegalStateException("Tried to start one server when none are terminated");
+    }
     safeStart(server);
     
     // Wait for it to start up (otherwise, later calls to wait for the servers to become ready may not know that


### PR DESCRIPTION
This addresses a possible, but previously unlikely, start-up failure race condition as well as putting the initial state of the framework into a more deterministic shape.  Server bootstrap finishes before returning control.