### PR TITLE
Fix Galvan unit tests and add some more verbose logging

### DIFF
--- a/galvan-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
+++ b/galvan-support/src/main/java/org/terracotta/testing/rules/BasicExternalCluster.java
@@ -167,7 +167,12 @@ public class BasicExternalCluster extends Cluster {
           didPass = false;
         }
         // Whether we passed or failed, bring everything down.
-        interlock.forceShutdown();
+        try {
+          interlock.forceShutdown();
+        } catch (GalvanFailureException e) {
+          e.printStackTrace();
+          didPass = false;
+        }
         setSafeForRun(false);
         if (!didPass) {
           // Typically, we want to interrupt the thread running as the "client" as it might be stuck in a connection

--- a/galvan/src/main/java/org/terracotta/testing/master/ClientEventManager.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ClientEventManager.java
@@ -112,7 +112,7 @@ public class ClientEventManager {
           call.runWithControl(control);
         } catch (Throwable t) {
           System.err.println("WARNING:  Client being sent FATAL ack (while processing " + eventNameBase + ") due to internal error: " + t);
-          responseToSend = IPCMessageConstants.FATAL_CLUSTER_ACK;
+          responseToSend = IPCMessageConstants.FATAL_CLUSTER_ACK + " " + t.getMessage();
         }
         // We also want to send the ACK to the client.
         processStdin.println(responseToSend);

--- a/galvan/src/main/java/org/terracotta/testing/master/GalvanStateInterlock.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/GalvanStateInterlock.java
@@ -105,7 +105,7 @@ public class GalvanStateInterlock implements IGalvanStateInterlock {
       while (!this.sharedLockState.checkDidPass() && (null == this.activeServer)) {
         safeWait();
       }
-      this.logger.output("< waitForActiveServer");
+      this.logger.output("< waitForActiveServer " + this.activeServer);
     }
   }
 
@@ -167,7 +167,7 @@ public class GalvanStateInterlock implements IGalvanStateInterlock {
   @Override
   public ServerProcess getActiveServer() throws GalvanFailureException {
     synchronized (this.sharedLockState) {
-      this.logger.output("getActiveServer");
+      this.logger.output("getActiveServer " + this.activeServer);
       this.sharedLockState.checkDidPass();
       return this.activeServer;
     }

--- a/galvan/src/main/java/org/terracotta/testing/master/GalvanStateInterlock.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/GalvanStateInterlock.java
@@ -17,6 +17,7 @@ package org.terracotta.testing.master;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.concurrent.TimeUnit;
 
 import org.terracotta.testing.common.Assert;
 import org.terracotta.testing.logging.ContextualLogger;
@@ -154,6 +155,14 @@ public class GalvanStateInterlock implements IGalvanStateInterlock {
     }
   }
 
+  private void safeWaitWithTimeout(long time, TimeUnit units) {
+    try {
+      this.sharedLockState.wait(units.toMillis(time));
+    } catch (InterruptedException e) {
+      Assert.unexpected(e);
+    }
+  }
+  
   private void safeWait() {
     try {
       this.sharedLockState.wait();
@@ -311,7 +320,7 @@ public class GalvanStateInterlock implements IGalvanStateInterlock {
 
   // ----- CLEANUP-----
   @Override
-  public void forceShutdown() {
+  public void forceShutdown() throws GalvanFailureException {
     synchronized (this.sharedLockState) {
       this.logger.output("> forceShutdown");
       // Set the flag that we are shutting down.  That way, any servers which were concurrently coming online can be stopped when they check in.
@@ -330,21 +339,31 @@ public class GalvanStateInterlock implements IGalvanStateInterlock {
       if (null != this.activeServer) {
         safeStop(this.activeServer);
       }
-      
+//  trying to debug a Galvan hang where not all the servers are seen
+      long timeExpired = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);
       // We wait until there is no active, no passives, no unknown servers, and no running clients.
-      while (
+      while (timeExpired > System.currentTimeMillis() && (
           (null != this.activeServer)
           || !this.passiveServers.isEmpty()
           || !this.unknownRunningServers.isEmpty()
           || !this.runningClients.isEmpty()
+        )
       ) {
         this.logger.output("* forceShutdown waiting on active: " + (null != this.activeServer)
             + " passives: " + this.passiveServers.size()
             + " unknown: " + this.unknownRunningServers.size()
             + " clients: " + this.runningClients.size()
             );
-        safeWait();
+        safeWaitWithTimeout(1, TimeUnit.MINUTES);
       }
+      if (System.currentTimeMillis() > timeExpired) {
+        this.logger.output("* forceShutdown FAILED waiting on active: " + (null != this.activeServer)
+            + " passives: " + this.passiveServers.size()
+            + " unknown: " + this.unknownRunningServers.size()
+            + " clients: " + this.runningClients.size());
+        throw new RuntimeException("FORCE SHUTDOWN FAILED:" + toString());
+      }
+      
       this.logger.output("< forceShutdown");
     }
   }

--- a/galvan/src/main/java/org/terracotta/testing/master/IGalvanStateInterlock.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/IGalvanStateInterlock.java
@@ -159,5 +159,5 @@ public interface IGalvanStateInterlock {
    * that they are offline.
    * Note that this doesn't throw, on test failure, since it is assumed that this is being called AFTER the test has run.
    */
-  public void forceShutdown();
+  public void forceShutdown() throws GalvanFailureException;
 }

--- a/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
@@ -340,11 +340,11 @@ public class ServerProcess {
     // See if we have a PID yet or if this was a failure, much earlier (hence, if we told the interlock that we are even running).
     GalvanFailureException failureException = null;
     long originalPid = this.waitForPid();
-    if (originalPid > 0) {
-      // Ok, tell the interlock.
-      this.stateInterlock.serverDidShutdown(this);
-    } else {
-      // This is a fast-failure so report the test failure.
+//  no matter what, the server is gone so report it to interlock
+    this.stateInterlock.serverDidShutdown(this);
+    if (!this.isCrashExpected() && originalPid == 0) {
+// didn't have time to get the PID, this is not expected
+      Assert.assertFalse(this.isCrashExpected()); // can't expect a crash without a PID
       failureException = new GalvanFailureException("Server crashed before reporting PID: " + this);
     }
     if (!this.isCrashExpected() && (null == failureException)) {

--- a/galvan/src/test/java/org/terracotta/testing/master/GalvanStateInterlockTest.java
+++ b/galvan/src/test/java/org/terracotta/testing/master/GalvanStateInterlockTest.java
@@ -75,7 +75,6 @@ public class GalvanStateInterlockTest {
         // Zap the unknown server.
         GalvanStateInterlockTest.this.interlock.serverWasZapped(passive);
         // Start up the zapped server and have it come up as a passive.
-        GalvanStateInterlockTest.this.interlock.serverDidStartup(passive);
         GalvanStateInterlockTest.this.interlock.serverBecamePassive(passive);
       }
     };
@@ -109,7 +108,6 @@ public class GalvanStateInterlockTest {
         // Zap the passive.
         GalvanStateInterlockTest.this.interlock.serverWasZapped(passive);
         // Start up the zapped server and have it come up as a passive.
-        GalvanStateInterlockTest.this.interlock.serverDidStartup(passive);
         GalvanStateInterlockTest.this.interlock.serverBecamePassive(passive);
         // Now, have the slow server become passive.
         GalvanStateInterlockTest.this.interlock.serverBecamePassive(slow);
@@ -147,7 +145,6 @@ public class GalvanStateInterlockTest {
         // Promote the passive.
         GalvanStateInterlockTest.this.interlock.serverBecameActive(passive);
         // Start up the zapped server and have it come up as a passive.
-        GalvanStateInterlockTest.this.interlock.serverDidStartup(active);
         GalvanStateInterlockTest.this.interlock.serverBecamePassive(active);
         // Now, have the slow server become passive.
         GalvanStateInterlockTest.this.interlock.serverBecamePassive(slow);


### PR DESCRIPTION
This fixes the broken unit tests to the new style.  I think one possible remaining problem is that some helper methods combine calls to methods in `IClusterControl` to provide a desired action.  For example, If you want to restart the active a common pattern might be 

```
IClusterControl.waitForActive()
IClusterControl.terminateActive()
IClusterControl.waitForActive()
```
If doing this from two different clients, the operations can step on each other and one will fail when it fails to see an active.  Maybe we should be more tolerant of this and simply noop when no active is present on terminate active