### PR TITLE
Fix early failure of a test setup.  

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
@@ -89,7 +89,12 @@ public class ReadyStripe {
     interlock.waitForAllServerRunning();
     
     // Also, so we don't start the test in a racy state, wait for all the now-running servers to enter a meaningful state.
-    interlock.waitForAllServerReady();
+    try {
+      interlock.waitForAllServerReady();
+    } catch (GalvanFailureException failed) {
+//  failed to start normally but some later interaction with the framework should catch this
+      System.err.println("Galvan cluster failed to start:" + failed.getMessage());
+    }
     
     // We can now create the information required by the ReadyStripe and return control to the caller to run the test or install clients.
     SynchronousProcessControl processControl = new SynchronousProcessControl(interlock, processControlLogger);


### PR DESCRIPTION
ReadyStripe should not be throwing GalvanFailureExceptions.  Later interactions with the framework will properly handle the failure.  ReadyStripe is setting up so just report to err and move on.