### PR TITLE
Make reconnect window configurable

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/api/ITestMaster.java
+++ b/galvan/src/main/java/org/terracotta/testing/api/ITestMaster.java
@@ -15,6 +15,8 @@
  */
 package org.terracotta.testing.api;
 
+import org.terracotta.testing.master.ConfigBuilder;
+
 import java.util.List;
 
 
@@ -24,6 +26,13 @@ public interface ITestMaster<C extends ITestClusterConfiguration> {
   public String getServiceConfigXMLSnippet();
 
   public String getEntityConfigXMLSnippet();
+
+  /**
+   * @return client reconnect window time in seconds
+   */
+  default int getClientReconnectWindowTime() {
+    return ConfigBuilder.DEFAULT_CLIENT_RECONNECT_WINDOW_TIME;
+  }
 
   /**
    * @return A list of paths to JARs which must be copied to the server kit being used in the test.

--- a/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
@@ -76,6 +76,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     String namespaceFragment = master.getConfigNamespaceSnippet();
     String serviceFragment = master.getServiceConfigXMLSnippet();
     String entityFragment = master.getEntityConfigXMLSnippet();
+    int clientReconnectWindowTime = master.getClientReconnectWindowTime();
     List<C> runConfigurations = master.getRunConfigurations();
     int clientsToCreate = master.getClientsToStart();
     for (C runConfiguration : runConfigurations) {
@@ -95,6 +96,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
       harnessOptions.namespaceFragment = namespaceFragment;
       harnessOptions.serviceFragment = serviceFragment;
       harnessOptions.entityFragment = entityFragment;
+      harnessOptions.clientReconnectWindowTime = clientReconnectWindowTime;
       
       // NOTE:  runOneConfiguration() throws GalvanFailureException on failure.
       runOneConfiguration(verboseManager, debugOptions, harnessOptions, runConfiguration);
@@ -139,6 +141,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     public String errorClassName;
     public int serverHeapInM;
     public List<String> extraJarPaths;
+    public int clientReconnectWindowTime;
     public String namespaceFragment;
     public String serviceFragment;
     public String entityFragment;

--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -31,7 +31,7 @@ public class CommonIdioms {
     VerboseManager stripeVerboseManager = verboseManager.createComponentManager("[" + stripeConfiguration.stripeName + "]");
     // We want to create a sub-directory per-stripe.
     String stripeParentDirectory = FileHelpers.createTempEmptyDirectory(stripeConfiguration.testParentDirectory, stripeConfiguration.stripeName);
-    return ReadyStripe.configureAndStartStripe(interlock, stateManager, stripeVerboseManager, stripeConfiguration.kitOriginPath, stripeParentDirectory, stripeConfiguration.serversToCreate, stripeConfiguration.serverHeapInM, stripeConfiguration.serverStartPort, stripeConfiguration.serverDebugPortStart, stripeConfiguration.serverStartNumber, stripeConfiguration.extraJarPaths, stripeConfiguration.namespaceFragment, stripeConfiguration.serviceFragment, stripeConfiguration.entityFragment);
+    return ReadyStripe.configureAndStartStripe(interlock, stateManager, stripeVerboseManager, stripeConfiguration.kitOriginPath, stripeParentDirectory, stripeConfiguration.serversToCreate, stripeConfiguration.serverHeapInM, stripeConfiguration.serverStartPort, stripeConfiguration.serverDebugPortStart, stripeConfiguration.serverStartNumber, stripeConfiguration.extraJarPaths, stripeConfiguration.namespaceFragment, stripeConfiguration.serviceFragment, stripeConfiguration.entityFragment, stripeConfiguration.clientReconnectWindowTime);
   }
   /**
    * Note that the clients will be run in another thread, logging to the given logger and returning their state in stateManager.
@@ -65,6 +65,7 @@ public class CommonIdioms {
     public int serverStartPort;
     public int serverDebugPortStart;
     public int serverStartNumber;
+    public int clientReconnectWindowTime;
     public List<String> extraJarPaths;
     public String namespaceFragment;
     public String serviceFragment;

--- a/galvan/src/main/java/org/terracotta/testing/master/ConfigBuilder.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ConfigBuilder.java
@@ -25,6 +25,9 @@ import org.terracotta.testing.logging.ContextualLogger;
 
 
 public class ConfigBuilder {
+
+  public static final int DEFAULT_CLIENT_RECONNECT_WINDOW_TIME = 120;
+
   public static ConfigBuilder buildStartPort(ContextualLogger logger, int startPort) {
     return new ConfigBuilder(logger, startPort);
   }
@@ -37,6 +40,7 @@ public class ConfigBuilder {
   private String xmlNamespaceFragment;
   private String serviceXMLSnippet;
   private String entityXMLSnippet;
+  private int clientReconnectWindowTime; // in secs
   
   private ConfigBuilder(ContextualLogger logger, int startPort) {
     this.logger = logger;
@@ -65,6 +69,11 @@ public class ConfigBuilder {
 
   public ConfigBuilder setEntitySnippet(String entityFragment) {
     this.entityXMLSnippet = entityFragment;
+    return this;
+  }
+
+  public ConfigBuilder setClientReconnectWindowTime(final int clientReconnectWindowTime) {
+    this.clientReconnectWindowTime = clientReconnectWindowTime;
     return this;
   }
 
@@ -101,8 +110,8 @@ public class ConfigBuilder {
           + "    </server>\n";
       servers += oneServer;
     }
-    String post = 
-          "    <client-reconnect-window>120</client-reconnect-window>\n"
+    String post =
+        "    <client-reconnect-window>" + this.clientReconnectWindowTime + "</client-reconnect-window>\n"
         + "  </servers>\n"
         + "</tc-config>\n";
     return pre + services + postservices + entities + postentities + servers + post;

--- a/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
@@ -52,7 +52,7 @@ public class ReadyStripe {
    * @throws IOException Thrown in case something went wrong during server installation.
    * @throws GalvanFailureException Thrown in case starting the servers in the stripe experienced a failure.
    */
-  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String kitOriginDirectory, int serversToCreate, int heapInM, int serverStartPort, int serverDebugPortStart, int serverStartNumber, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment) throws IOException, GalvanFailureException {
+  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String kitOriginDirectory, int serversToCreate, int heapInM, int serverStartPort, int serverDebugPortStart, int serverStartNumber, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment, int clientReconnectWindowTime) throws IOException, GalvanFailureException {
     ContextualLogger configLogger = stripeVerboseManager.createComponentManager("[ConfigBuilder]").createHarnessLogger();
     // Create the config builder.
     ConfigBuilder configBuilder = ConfigBuilder.buildStartPort(configLogger, serverStartPort);
@@ -60,6 +60,7 @@ public class ReadyStripe {
     configBuilder.setNamespaceSnippet(namespaceFragment);
     configBuilder.setServiceSnippet(serviceFragment);
     configBuilder.setEntitySnippet(entityFragment);
+    configBuilder.setClientReconnectWindowTime(clientReconnectWindowTime);
     // Create the stripe installer.
     StripeInstaller installer = new StripeInstaller(interlock, stateManager, stripeVerboseManager, kitOriginDirectory, serverInstallDirectory, extraJarPaths);
     // Configure and install each server in the stripe.
@@ -98,8 +99,11 @@ public class ReadyStripe {
     ClusterInfo clusterInfo = configBuilder.getClusterInfo();
     return new ReadyStripe(processControl, connectUri, clusterInfo, configText);
   }
-  
-  
+
+  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String kitOriginDirectory, int serversToCreate, int heapInM, int serverStartPort, int serverDebugPortStart, int serverStartNumber, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment) throws IOException, GalvanFailureException {
+    return configureAndStartStripe(interlock, stateManager, stripeVerboseManager, serverInstallDirectory, kitOriginDirectory, serversToCreate, heapInM, serverStartPort, serverDebugPortStart, serverStartNumber, extraJarPaths, namespaceFragment, serviceFragment, entityFragment, ConfigBuilder.DEFAULT_CLIENT_RECONNECT_WINDOW_TIME);
+  }
+
   public final IMultiProcessControl stripeControl;
   public final String stripeUri;
   public final ClusterInfo clusterInfo;


### PR DESCRIPTION
current default reconnect window time is 120 seconds, which is increasing build time unnecessarily when running tests in Terracotta-OSS/terracotta-core. This PR is for making reconnect window time configurable to reduce/increase it when needed.   