### PR TITLE
Make reconnect default the default at object create

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -65,7 +65,7 @@ public class CommonIdioms {
     public int serverStartPort;
     public int serverDebugPortStart;
     public int serverStartNumber;
-    public int clientReconnectWindowTime;
+    public int clientReconnectWindowTime = ConfigBuilder.DEFAULT_CLIENT_RECONNECT_WINDOW_TIME;
     public List<String> extraJarPaths;
     public String namespaceFragment;
     public String serviceFragment;


### PR DESCRIPTION
We aren't passing the default from the harness options to the stripe options in many places.  This makes the default carry no matter what