### PR TITLE
Fix #147 - ServerProcess: open stdout.log/stderr.log for appending

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
@@ -129,9 +129,9 @@ public class ServerProcess {
     // Now, open the log files.
     // We want to create an output log file for both STDOUT and STDERR.
     // rawOut closed by stdout
-    FileOutputStream rawOut = new FileOutputStream(new File(this.serverWorkingDirectory, "stdout.log"));
+    FileOutputStream rawOut = new FileOutputStream(new File(this.serverWorkingDirectory, "stdout.log"), true);
     // rawErr closed by stderr
-    FileOutputStream rawErr = new FileOutputStream(new File(this.serverWorkingDirectory, "stderr.log"));
+    FileOutputStream rawErr = new FileOutputStream(new File(this.serverWorkingDirectory, "stderr.log"), true);
     // We also want to stream output going to these files to the server's logger.
     // stdout closed by outputStream
     VerboseOutputStream stdout = new VerboseOutputStream(rawOut, this.serverLogger, false);


### PR DESCRIPTION
**verification**

**with fix - stdout.log has both before and after restart logs**
➜  system-tests git:(master) ✗ grep 'Terracotta 5.3-SNAPSHOT' target/test-classes/testing_directory/org.terracotta.kit_testing.GalvanBarrierTest/OneActive/stripe0/testServer0/stdout.log
2017-07-26 00:17:23,036 [main] INFO com.tc.server.TCServerMain - Terracotta 5.3-SNAPSHOT, as of 2017-07-21 at 08:51:16 PDT (Revision caa40536902a2cebcde94ea1b37b1ca730a02d88 from UNKNOWN)
2017-07-26 00:17:34,451 [main] INFO com.tc.server.TCServerMain - Terracotta 5.3-SNAPSHOT, as of 2017-07-21 at 08:51:16 PDT (Revision caa40536902a2cebcde94ea1b37b1ca730a02d88 from UNKNOWN)
➜  system-tests git:(master) ✗

**without fix - stdout.log has only after restart logs**
➜  system-tests git:(master) ✗ grep 'Terracotta 5.3-SNAPSHOT' target/test-classes/testing_directory/org.terracotta.kit_testing.GalvanBarrierTest/OneActive/stripe0/testServer0/stdout.log

2017-07-26 00:13:59,466 [main] INFO com.tc.server.TCServerMain - Terracotta 5.3-SNAPSHOT, as of 2017-07-21 at 08:51:16 PDT (Revision caa40536902a2cebcde94ea1b37b1ca730a02d88 from UNKNOWN)
➜  system-tests git:(master) ✗