### PR TITLE
Fix #159: Add support for overriding tc properties

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/api/ITestMaster.java
+++ b/galvan/src/main/java/org/terracotta/testing/api/ITestMaster.java
@@ -18,6 +18,7 @@ package org.terracotta.testing.api;
 import org.terracotta.testing.master.ConfigBuilder;
 
 import java.util.List;
+import java.util.Properties;
 
 
 public interface ITestMaster<C extends ITestClusterConfiguration> {
@@ -27,6 +28,12 @@ public interface ITestMaster<C extends ITestClusterConfiguration> {
 
   public String getEntityConfigXMLSnippet();
 
+  /**
+   * @return tc properties to be used with server
+   */
+  default Properties getTcProperties() {
+    return new Properties();
+  }
   /**
    * @return client reconnect window time in seconds
    */

--- a/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
@@ -18,6 +18,7 @@ package org.terracotta.testing.master;
 import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.List;
+import java.util.Properties;
 
 import org.terracotta.testing.api.ITestClusterConfiguration;
 import org.terracotta.testing.api.ITestMaster;
@@ -77,6 +78,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     String serviceFragment = master.getServiceConfigXMLSnippet();
     String entityFragment = master.getEntityConfigXMLSnippet();
     int clientReconnectWindowTime = master.getClientReconnectWindowTime();
+    Properties tcProperties = master.getTcProperties();
     List<C> runConfigurations = master.getRunConfigurations();
     int clientsToCreate = master.getClientsToStart();
     for (C runConfiguration : runConfigurations) {
@@ -97,6 +99,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
       harnessOptions.serviceFragment = serviceFragment;
       harnessOptions.entityFragment = entityFragment;
       harnessOptions.clientReconnectWindowTime = clientReconnectWindowTime;
+      harnessOptions.tcProperties = tcProperties;
       
       // NOTE:  runOneConfiguration() throws GalvanFailureException on failure.
       runOneConfiguration(verboseManager, debugOptions, harnessOptions, runConfiguration);
@@ -145,6 +148,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     public String namespaceFragment;
     public String serviceFragment;
     public String entityFragment;
+    public Properties tcProperties;
     
     /**
      * This constructor only exists to set convenient defaults.

--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -17,6 +17,7 @@ package org.terracotta.testing.master;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 import java.util.Vector;
 
 import org.terracotta.testing.logging.VerboseManager;
@@ -31,7 +32,7 @@ public class CommonIdioms {
     VerboseManager stripeVerboseManager = verboseManager.createComponentManager("[" + stripeConfiguration.stripeName + "]");
     // We want to create a sub-directory per-stripe.
     String stripeParentDirectory = FileHelpers.createTempEmptyDirectory(stripeConfiguration.testParentDirectory, stripeConfiguration.stripeName);
-    return ReadyStripe.configureAndStartStripe(interlock, stateManager, stripeVerboseManager, stripeConfiguration.kitOriginPath, stripeParentDirectory, stripeConfiguration.serversToCreate, stripeConfiguration.serverHeapInM, stripeConfiguration.serverStartPort, stripeConfiguration.serverDebugPortStart, stripeConfiguration.serverStartNumber, stripeConfiguration.extraJarPaths, stripeConfiguration.namespaceFragment, stripeConfiguration.serviceFragment, stripeConfiguration.entityFragment, stripeConfiguration.clientReconnectWindowTime);
+    return ReadyStripe.configureAndStartStripe(interlock, stateManager, stripeVerboseManager, stripeConfiguration.kitOriginPath, stripeParentDirectory, stripeConfiguration.serversToCreate, stripeConfiguration.serverHeapInM, stripeConfiguration.serverStartPort, stripeConfiguration.serverDebugPortStart, stripeConfiguration.serverStartNumber, stripeConfiguration.extraJarPaths, stripeConfiguration.namespaceFragment, stripeConfiguration.serviceFragment, stripeConfiguration.entityFragment, stripeConfiguration.clientReconnectWindowTime, stripeConfiguration.tcProperties);
   }
   /**
    * Note that the clients will be run in another thread, logging to the given logger and returning their state in stateManager.
@@ -66,6 +67,7 @@ public class CommonIdioms {
     public int serverDebugPortStart;
     public int serverStartNumber;
     public int clientReconnectWindowTime = ConfigBuilder.DEFAULT_CLIENT_RECONNECT_WINDOW_TIME;
+    public Properties tcProperties;
     public List<String> extraJarPaths;
     public String namespaceFragment;
     public String serviceFragment;

--- a/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
@@ -17,6 +17,7 @@ package org.terracotta.testing.master;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
 
 import org.terracotta.testing.logging.ContextualLogger;
 import org.terracotta.testing.logging.VerboseManager;
@@ -52,7 +53,7 @@ public class ReadyStripe {
    * @throws IOException Thrown in case something went wrong during server installation.
    * @throws GalvanFailureException Thrown in case starting the servers in the stripe experienced a failure.
    */
-  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String kitOriginDirectory, int serversToCreate, int heapInM, int serverStartPort, int serverDebugPortStart, int serverStartNumber, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment, int clientReconnectWindowTime) throws IOException, GalvanFailureException {
+  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String kitOriginDirectory, int serversToCreate, int heapInM, int serverStartPort, int serverDebugPortStart, int serverStartNumber, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment, int clientReconnectWindowTime, Properties tcProperties) throws IOException, GalvanFailureException {
     ContextualLogger configLogger = stripeVerboseManager.createComponentManager("[ConfigBuilder]").createHarnessLogger();
     // Create the config builder.
     ConfigBuilder configBuilder = ConfigBuilder.buildStartPort(configLogger, serverStartPort);
@@ -61,6 +62,7 @@ public class ReadyStripe {
     configBuilder.setServiceSnippet(serviceFragment);
     configBuilder.setEntitySnippet(entityFragment);
     configBuilder.setClientReconnectWindowTime(clientReconnectWindowTime);
+    configBuilder.addTcProperties(tcProperties);
     // Create the stripe installer.
     StripeInstaller installer = new StripeInstaller(interlock, stateManager, stripeVerboseManager, kitOriginDirectory, serverInstallDirectory, extraJarPaths);
     // Configure and install each server in the stripe.
@@ -100,8 +102,12 @@ public class ReadyStripe {
     return new ReadyStripe(processControl, connectUri, clusterInfo, configText);
   }
 
+  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String kitOriginDirectory, int serversToCreate, int heapInM, int serverStartPort, int serverDebugPortStart, int serverStartNumber, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment, int clientReconnectWindowTime) throws IOException, GalvanFailureException {
+    return configureAndStartStripe(interlock, stateManager, stripeVerboseManager, serverInstallDirectory, kitOriginDirectory, serversToCreate, heapInM, serverStartPort, serverDebugPortStart, serverStartNumber, extraJarPaths, namespaceFragment, serviceFragment, entityFragment, clientReconnectWindowTime, new Properties());
+  }
+
   public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String kitOriginDirectory, int serversToCreate, int heapInM, int serverStartPort, int serverDebugPortStart, int serverStartNumber, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment) throws IOException, GalvanFailureException {
-    return configureAndStartStripe(interlock, stateManager, stripeVerboseManager, serverInstallDirectory, kitOriginDirectory, serversToCreate, heapInM, serverStartPort, serverDebugPortStart, serverStartNumber, extraJarPaths, namespaceFragment, serviceFragment, entityFragment, ConfigBuilder.DEFAULT_CLIENT_RECONNECT_WINDOW_TIME);
+    return configureAndStartStripe(interlock, stateManager, stripeVerboseManager, serverInstallDirectory, kitOriginDirectory, serversToCreate, heapInM, serverStartPort, serverDebugPortStart, serverStartNumber, extraJarPaths, namespaceFragment, serviceFragment, entityFragment, ConfigBuilder.DEFAULT_CLIENT_RECONNECT_WINDOW_TIME, new Properties());
   }
 
   public final IMultiProcessControl stripeControl;


### PR DESCRIPTION
This PR adds support for overriding tc properties when using galvan framework, given tc properties will be added to tc config xml using `tc-properties` tag. 