### PR TITLE
Fix #170 Add a mechanism to pass System.property to galvan process

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/api/ITestMaster.java
+++ b/galvan/src/main/java/org/terracotta/testing/api/ITestMaster.java
@@ -34,6 +34,11 @@ public interface ITestMaster<C extends ITestClusterConfiguration> {
   default Properties getTcProperties() {
     return new Properties();
   }
+
+  default Properties getServerProperties() {
+    return new Properties();
+  }
+
   /**
    * @return client reconnect window time in seconds
    */

--- a/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
@@ -31,7 +31,8 @@ import org.terracotta.testing.logging.VerboseManager;
 public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> {
   private final PortChooser chooser = new PortChooser();
   
-  public void runTestHarness(EnvironmentOptions environmentOptions, ITestMaster<C> master, DebugOptions debugOptions, VerboseManager verboseManager) throws IOException, GalvanFailureException {
+  public void runTestHarness(EnvironmentOptions environmentOptions, ITestMaster<C> master, DebugOptions debugOptions,
+                             VerboseManager verboseManager) throws IOException, GalvanFailureException {
     // Before anything, set the default exception handler - since we create threads to manage the sub-processes.
     Thread.setDefaultUncaughtExceptionHandler(new GalvanExceptionHandler());
     
@@ -50,7 +51,8 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     return chooser.chooseRandomPorts(number);
   }
 
-  private void internalRunTestHarness(EnvironmentOptions environmentOptions, ITestMaster<C> master, DebugOptions debugOptions, VerboseManager verboseManager) throws IOException, GalvanFailureException {
+  private void internalRunTestHarness(EnvironmentOptions environmentOptions, ITestMaster<C> master, DebugOptions debugOptions,
+                                      VerboseManager verboseManager) throws IOException, GalvanFailureException {
     // Validate the parameters.
     Assert.assertTrue(environmentOptions.isValid());
     
@@ -79,6 +81,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     String entityFragment = master.getEntityConfigXMLSnippet();
     int clientReconnectWindowTime = master.getClientReconnectWindowTime();
     Properties tcProperties = master.getTcProperties();
+    Properties serverProperties = master.getServerProperties();
     List<C> runConfigurations = master.getRunConfigurations();
     int clientsToCreate = master.getClientsToStart();
     for (C runConfiguration : runConfigurations) {
@@ -101,6 +104,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
       harnessOptions.entityFragment = entityFragment;
       harnessOptions.clientReconnectWindowTime = clientReconnectWindowTime;
       harnessOptions.tcProperties = tcProperties;
+      harnessOptions.serverProperties = serverProperties;
       
       // NOTE:  runOneConfiguration() throws GalvanFailureException on failure.
       runOneConfiguration(verboseManager, debugOptions, harnessOptions, runConfiguration);
@@ -151,6 +155,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
     public String serviceFragment;
     public String entityFragment;
     public Properties tcProperties;
+    public Properties serverProperties;
     
     /**
      * This constructor only exists to set convenient defaults.

--- a/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/CommonIdioms.java
@@ -28,11 +28,18 @@ import org.terracotta.testing.logging.VerboseManager;
  * It exists purely to avoid duplication.
  */
 public class CommonIdioms {
-  public static ReadyStripe setupConfigureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager verboseManager, StripeConfiguration stripeConfiguration) throws IOException, GalvanFailureException {
+  public static ReadyStripe setupConfigureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager,
+                                                         VerboseManager verboseManager, StripeConfiguration stripeConfiguration)
+      throws IOException, GalvanFailureException {
     VerboseManager stripeVerboseManager = verboseManager.createComponentManager("[" + stripeConfiguration.stripeName + "]");
     // We want to create a sub-directory per-stripe.
     String stripeParentDirectory = FileHelpers.createTempEmptyDirectory(stripeConfiguration.testParentDirectory, stripeConfiguration.stripeName);
-    return ReadyStripe.configureAndStartStripe(interlock, stateManager, stripeVerboseManager, stripeConfiguration.kitOriginPath, stripeParentDirectory, stripeConfiguration.serversToCreate, stripeConfiguration.serverHeapInM, stripeConfiguration.serverStartPort, stripeConfiguration.serverDebugPortStart, stripeConfiguration.serverStartNumber, stripeConfiguration.extraJarPaths, stripeConfiguration.namespaceFragment, stripeConfiguration.serviceFragment, stripeConfiguration.entityFragment, stripeConfiguration.clientReconnectWindowTime, stripeConfiguration.tcProperties, stripeConfiguration.logConfigExtension);
+    return ReadyStripe.configureAndStartStripe(interlock, stateManager, stripeVerboseManager,
+        stripeConfiguration.kitOriginPath, stripeParentDirectory, stripeConfiguration.serversToCreate,
+        stripeConfiguration.serverHeapInM, stripeConfiguration.serverStartPort, stripeConfiguration.serverDebugPortStart,
+        stripeConfiguration.serverStartNumber, stripeConfiguration.extraJarPaths, stripeConfiguration.namespaceFragment,
+        stripeConfiguration.serviceFragment, stripeConfiguration.entityFragment, stripeConfiguration.clientReconnectWindowTime,
+        stripeConfiguration.tcProperties, stripeConfiguration.serverProperties, stripeConfiguration.logConfigExtension);
   }
   /**
    * Note that the clients will be run in another thread, logging to the given logger and returning their state in stateManager.
@@ -68,6 +75,7 @@ public class CommonIdioms {
     public int serverStartNumber;
     public int clientReconnectWindowTime = ConfigBuilder.DEFAULT_CLIENT_RECONNECT_WINDOW_TIME;
     public Properties tcProperties;
+    public Properties serverProperties;
     public List<String> extraJarPaths;
     public String namespaceFragment;
     public String serviceFragment;

--- a/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ReadyStripe.java
@@ -49,11 +49,20 @@ public class ReadyStripe {
    * @param namespaceFragment The namespace declaration string which must be injected into each config.
    * @param serviceFragment The service definition string which must be injected into each config.
    * @param entityFragment The static/built-in entity definition string which must be injected into each config.
+   * @param serverProperties the Java system properties to apply to to each stripe server
    * @return The objects required to interact with and control the stripe.
    * @throws IOException Thrown in case something went wrong during server installation.
    * @throws GalvanFailureException Thrown in case starting the servers in the stripe experienced a failure.
    */
-  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverInstallDirectory, String kitOriginDirectory, int serversToCreate, int heapInM, int serverStartPort, int serverDebugPortStart, int serverStartNumber, List<String> extraJarPaths, String namespaceFragment, String serviceFragment, String entityFragment, int clientReconnectWindowTime, Properties tcProperties, String logConfigExt) throws IOException, GalvanFailureException {
+  public static ReadyStripe configureAndStartStripe(GalvanStateInterlock interlock, ITestStateManager stateManager,
+                                                    VerboseManager stripeVerboseManager, String serverInstallDirectory,
+                                                    String kitOriginDirectory, int serversToCreate, int heapInM,
+                                                    int serverStartPort, int serverDebugPortStart, int serverStartNumber,
+                                                    List<String> extraJarPaths, String namespaceFragment,
+                                                    String serviceFragment, String entityFragment,
+                                                    int clientReconnectWindowTime, Properties tcProperties,
+                                                    Properties serverProperties, String logConfigExt)
+      throws IOException, GalvanFailureException {
     ContextualLogger configLogger = stripeVerboseManager.createComponentManager("[ConfigBuilder]").createHarnessLogger();
     // Create the config builder.
     ConfigBuilder configBuilder = ConfigBuilder.buildStartPort(configLogger, serverStartPort);
@@ -73,7 +82,7 @@ public class ReadyStripe {
           ? (serverDebugPortStart + i)
           : 0;
       configBuilder.addServer(serverName);
-      installer.installNewServer(serverName, heapInM, debugPort, logConfigExt);
+      installer.installNewServer(serverName, heapInM, debugPort, (serverProperties == null ? new Properties() : serverProperties), logConfigExt);
     }
     // The config is built and stripe has been installed so write the config to the stripe.
     String configText = configBuilder.buildConfig();

--- a/galvan/src/main/java/org/terracotta/testing/master/ServerInstallation.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerInstallation.java
@@ -18,6 +18,7 @@ package org.terracotta.testing.master;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Properties;
 
 import org.terracotta.testing.common.Assert;
 import org.terracotta.testing.logging.VerboseManager;
@@ -34,10 +35,12 @@ public class ServerInstallation {
   private final File serverWorkingDirectory;
   private final int heapInM;
   private final int debugPort;
+  private final Properties serverProperties;
   private boolean configWritten;
   private boolean hasCreatedProcess;
 
-  public ServerInstallation(GalvanStateInterlock stateInterlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String serverName, File serverWorkingDirectory, int heapInM, int debugPort) {
+  public ServerInstallation(GalvanStateInterlock stateInterlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager,
+                            String serverName, File serverWorkingDirectory, int heapInM, int debugPort, Properties serverProperties) {
     this.stateInterlock = stateInterlock;
     this.stateManager = stateManager;
     this.stripeVerboseManager = stripeVerboseManager;
@@ -45,6 +48,7 @@ public class ServerInstallation {
     this.serverWorkingDirectory = serverWorkingDirectory;
     this.heapInM = heapInM;
     this.debugPort = debugPort;
+    this.serverProperties = serverProperties;
   }
 
   public void overwriteConfig(String config) throws IOException {
@@ -73,7 +77,8 @@ public class ServerInstallation {
     // Create the VerboseManager for the instance.
     VerboseManager serverVerboseManager = this.stripeVerboseManager.createComponentManager("[" + this.serverName + "]");
     // Create the process and check it out.
-    ServerProcess process = new ServerProcess(this.stateInterlock, this.stateManager, serverVerboseManager, this, this.serverName, this.serverWorkingDirectory, this.heapInM, this.debugPort);
+    ServerProcess process = new ServerProcess(this.stateInterlock, this.stateManager, serverVerboseManager, this,
+        this.serverName, this.serverWorkingDirectory, this.heapInM, this.debugPort, this.serverProperties);
     this.hasCreatedProcess = true;
     return process;
   }

--- a/galvan/src/main/java/org/terracotta/testing/master/StripeInstaller.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/StripeInstaller.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Properties;
 import java.util.Vector;
 
 import org.terracotta.testing.common.Assert;
@@ -44,7 +45,8 @@ public class StripeInstaller {
   private final List<ServerInstallation> installedServers;
   private boolean isBuilt;
   
-  public StripeInstaller(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager, String stripeInstallDirectory, String kitOriginDirectory, List<String> extraJarPaths) {
+  public StripeInstaller(GalvanStateInterlock interlock, ITestStateManager stateManager, VerboseManager stripeVerboseManager,
+                         String stripeInstallDirectory, String kitOriginDirectory, List<String> extraJarPaths) {
     this.interlock = interlock;
     this.stateManager = stateManager;
     this.stripeVerboseManager = stripeVerboseManager;
@@ -55,7 +57,7 @@ public class StripeInstaller {
     this.installedServers = new Vector<ServerInstallation>();
   }
   
-  public void installNewServer(String serverName, int heapInM, int debugPort, String logConfigExt) throws IOException {
+  public void installNewServer(String serverName, int heapInM, int debugPort, Properties serverProperties, String logConfigExt) throws IOException {
     // Our implementation installs all servers before starting any (just an internal consistency check).
     Assert.assertFalse(this.isBuilt);
     // Create the logger for the intallation.
@@ -75,7 +77,8 @@ public class StripeInstaller {
     }
 
     // Create the object representing this single installation and add it to the list for this stripe.
-    ServerInstallation installation = new ServerInstallation(this.interlock, this.stateManager, this.stripeVerboseManager, serverName, new File(installPath), heapInM, debugPort);
+    ServerInstallation installation = new ServerInstallation(this.interlock, this.stateManager, this.stripeVerboseManager,
+        serverName, new File(installPath), heapInM, debugPort, serverProperties);
     this.installedServers.add(installation);
   }
   


### PR DESCRIPTION
This commit adds a Properties instance to the CommonIdioms structure
and that Propertoes instance is provided to the ServerProcess as Java system 
properties during server start.