### PR TITLE
#181 Correct server start failure under Linux

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/ServerProcess.java
@@ -234,7 +234,7 @@ public class ServerProcess {
       this.harnessLogger.output("NOTE:  Starting server \"" + this.serverName + "\" with debug port: " + debugPort);
     }
     String propertiesAsOptions = serverProperties.entrySet().stream()
-        .map(e -> "\"-D" + e.getKey() + "=" + e.getValue() + "\"")
+        .map(e -> "-D" + e.getKey() + "=" + e.getValue())
         .collect(joining(" "));
     if (!propertiesAsOptions.isEmpty()) {
       javaOpts += " " + propertiesAsOptions;


### PR DESCRIPTION
This commit removes the quoting used in #180 when adding the Java
system property values to JAVA_OPTS.  While the quoting works under
Windows, Linux re-quotes the quotes causing the resulting property
option to be unrecognized as a property option.