### PR TITLE
Correct line-end handling on Windows

### DIFF
--- a/galvan/src/main/java/org/terracotta/testing/common/SimpleEventingStream.java
+++ b/galvan/src/main/java/org/terracotta/testing/common/SimpleEventingStream.java
@@ -32,33 +32,52 @@ public class SimpleEventingStream extends OutputStream {
   private final Map<String, String> eventMap;
   private final OutputStream nextConsumer;
   private final ByteArrayOutputStream stream;
-  
+
+  private final boolean twoByteLineSeparator;
+  private final byte eol;
+  private final byte eolLeader;
+
+  private boolean haveLeader = false;
+
   public SimpleEventingStream(EventBus outputBus, Map<String, String> eventMap, OutputStream nextConsumer) {
     Assert.assertNotNull(nextConsumer);
     this.outputBus = outputBus;
     this.eventMap = eventMap;
     this.nextConsumer = nextConsumer;
     this.stream = new ByteArrayOutputStream();
+
+    String lineSeparator = System.lineSeparator();
+    this.twoByteLineSeparator = lineSeparator.length() == 2;
+    this.eol = (byte)lineSeparator.charAt(lineSeparator.length() - 1);
+    this.eolLeader = (byte)(this.twoByteLineSeparator ? lineSeparator.charAt(0) : '\0');
   }
 
   @Override
   public void write(int b) throws IOException {
-    if ('\n' == (byte)b) {
-      // End of line so we process the bytes to find matches and then replace it.
-      // NOTE:  This will use the platform's default encoding.
-      String oneLine = this.stream.toString();
-      // Determine what events to trigger by scraping the string for keys.
-      for (Map.Entry<String, String> pair : this.eventMap.entrySet()) {
-        if (-1 != oneLine.indexOf(pair.getKey())) {
-          this.outputBus.trigger(pair.getValue(), oneLine);
-        }
-      }
-      // Start the next line.
-      this.stream.reset();
+    if (twoByteLineSeparator && eolLeader == (byte)b) {
+      haveLeader = true;
     } else {
-      this.stream.write(b);
+      if (eol == (byte)b) {
+        // End of line so we process the bytes to find matches and then replace it.
+        // NOTE:  This will use the platform's default encoding.
+        String oneLine = this.stream.toString();
+        // Determine what events to trigger by scraping the string for keys.
+        for (Map.Entry<String, String> pair : this.eventMap.entrySet()) {
+          if (-1 != oneLine.indexOf(pair.getKey())) {
+            this.outputBus.trigger(pair.getValue(), oneLine);
+          }
+        }
+        // Start the next line.
+        this.stream.reset();
+      } else {
+        if (haveLeader) {
+          this.stream.write(eolLeader);
+        }
+        this.stream.write(b);
+      }
+      haveLeader = false;
+      this.nextConsumer.write(b);
     }
-    this.nextConsumer.write(b);
   }
 
   @Override


### PR DESCRIPTION
This commit prevents Galvan, when used on Windows, from emitting blank
lines and double-spaced lines to the console and file output, respectively.

Fixes #189 