### PR TITLE
Bump utilities

### DIFF
--- a/galvan/pom.xml
+++ b/galvan/pom.xml
@@ -81,6 +81,15 @@ limitations under the License.
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <org.terracotta.disablePortReleaseCheck>true</org.terracotta.disablePortReleaseCheck>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-source-plugin</artifactId>
         <version>2.4</version>
         <executions>

--- a/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
+++ b/galvan/src/main/java/org/terracotta/testing/master/AbstractHarnessEntry.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -88,7 +89,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
         /*
          * Close and discard any previously obtained PortRefs now.
          */
-        portRefs.forEach(PortManager.PortRef::close);
+        portRefs.forEach(ref -> ref.close(EnumSet.of(PortManager.PortRef.CloseOption.NO_RELEASE_CHECK)));
         portRefs.clear();
 
         portRefs.add(portRef);
@@ -112,7 +113,7 @@ public abstract class AbstractHarnessEntry<C extends ITestClusterConfiguration> 
       }
 
       if (portRefs.size() != number) {
-        portRefs.forEach(PortManager.PortRef::close);
+        portRefs.forEach(ref -> ref.close(EnumSet.of(PortManager.PortRef.CloseOption.NO_RELEASE_CHECK)));
         portRefs.clear();
         throw new IllegalStateException("Failed to obtain " + number + " consecutive ports within " + maxAttempts + " attempts");
       }

--- a/galvan/src/test/resources/logback.xml
+++ b/galvan/src/test/resources/logback.xml
@@ -6,6 +6,7 @@
   </appender>
 
   <logger name="org.terracotta.utilities.test.net.SystemLevelLocker" level="WARN"/>
+  <logger name="org.terracotta.utilities.test.net.PortManager" level="WARN"/>
 
   <root level="INFO">
     <appender-ref ref="STDOUT"/>

--- a/pom.xml
+++ b/pom.xml
@@ -85,28 +85,6 @@ limitations under the License.
     </snapshotRepository>
   </distributionManagement>
 
-  <repositories>
-    <repository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>
-    <repository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>http://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>
-
   <scm>
     <connection>scm:git:https://github.com/Terracotta-OSS/galvan.git</connection>
     <developerConnection>scm:git:https://github.com/Terracotta-OSS/galvan.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
 
     <!-- External dependency versions for the project -->
     <ipc-eventbus.version>1.1.1</ipc-eventbus.version>
-    <terracotta-utilities.version>0.0.9</terracotta-utilities.version>
+    <terracotta-utilities.version>0.0.13</terracotta-utilities.version>
     <logback.version>1.2.3</logback.version>
     <junit.version>4.12</junit.version>
   </properties>


### PR DESCRIPTION
This commit stream includes:

* Updates to adjust for PortManager port release check

This commit updates the version of terracotta-utilities to adapt to the
PortManager port release checker and PortRef.close options.

This commit changes the 'galvan' module's test execution to suppress
PortManager release checking.  It also re-enables one skipped test that
had an increased false failure rate due to the port release checking.

This test also changes internal calls to PortRef.close to use the "option"
version to avoid the port release checker overhead in
AbstractHarnessEntry.chooseRandomPortRange.  (Port release checking
continues to be enabled when the assigned ports are released.)

* Remove POM repositories elements

This commit reduces the repositories and pluginRepositories elements
to those required to locate the direct dependencies of this project.
More specifically, the SNAPSHOT repositories are removed -- inclusion
of SNAPSHOT repositories interferes with the use of range-based version
specifications.  Should a developer want to include a SNAPSHOT release
in a build, local addition of the SNAPSHOT repositories can be employed.