### PR TITLE
Use version range for logging components & terracotta-utilities

### DIFF
--- a/galvan/pom.xml
+++ b/galvan/pom.xml
@@ -37,7 +37,7 @@ limitations under the License.
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>${logback.version}</version>
+      <version>${logback.range.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -55,7 +55,7 @@ limitations under the License.
     <dependency>
       <groupId>org.terracotta</groupId>
       <artifactId>terracotta-utilities-port-chooser</artifactId>
-      <version>${terracotta-utilities.version}</version>
+      <version>${terracotta-utilities.range.version}</version>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,10 @@ limitations under the License.
 
     <!-- External dependency versions for the project -->
     <ipc-eventbus.version>1.1.1</ipc-eventbus.version>
-    <terracotta-utilities.version>0.0.13</terracotta-utilities.version>
-    <logback.version>1.2.3</logback.version>
+    <terracotta-utilities.base.version>0.0.13</terracotta-utilities.base.version>
+    <terracotta-utilities.range.version>[${terracotta-utilities.base.version},)</terracotta-utilities.range.version>
+    <logback.base.version>1.2.11</logback.base.version>
+    <logback.range.version>[${logback.base.version},1.2.9999)</logback.range.version>
     <junit.version>4.12</junit.version>
   </properties>
 


### PR DESCRIPTION
This commit bumps the version of Logback and shifts to the use of
version ranges for Logback.

This commit also introduces a version range for terracotta-utilities.
The minimum version is left unchanged but the upper is unbounded.